### PR TITLE
Fix: Replace hardcoded calendar end date with dynamic range

### DIFF
--- a/lib/screens/calendar/calendar_screen.dart
+++ b/lib/screens/calendar/calendar_screen.dart
@@ -370,7 +370,7 @@ Widget _buildCalendar() {
       padding: const EdgeInsets.all(8.0),
       child: TableCalendar(
         firstDay: DateTime.utc(2024, 1, 1),
-        lastDay: DateTime.utc(2025, 12, 31),
+        lastDay: DateTime.utc(DateTime.now().year + 5, 12, 31), // Dynamic: always 5 years ahead
         focusedDay: _focusedDay,
         calendarFormat: _calendarFormat,
         selectedDayPredicate: (day) => isSameDay(_selectedDay, day),


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #124 


## 📝 Description

This PR fixes a bug in the calendar widget where dates beyond December 31, 2025 could not be displayed or selected. The calendar was using a hardcoded `lastDay` parameter set to 2025, making it unusable for future dates as we've entered 2026.

The fix implements a dynamic date calculation that automatically sets the calendar's end date to 5 years from the current year, ensuring the calendar remains functional indefinitely without requiring future updates.

## 🔧 Changes Made

- Replaced hardcoded `lastDay: DateTime.utc(2025, 12, 31)` with dynamic calculation `DateTime.utc(DateTime.now().year + 5, 12, 31)`
- Calendar now automatically displays dates up to 5 years ahead from the current year
- Ensures calendar widget remains future-proof and requires no maintenance for date range updates

## 📷 Screenshots or Visual Changes (if applicable)

![bug-resolved](https://github.com/user-attachments/assets/d8b1df4e-cf1a-4f17-a72d-88dc919e36e6)


## 🤝 Collaboration
NA


### ✅ Checklist

- [ ] I have read the contributing guidelines.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if applicable).
- [ ] Any dependent changes have been merged and published in downstream modules.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated calendar date range to dynamically extend five years from the current year, replacing the previously fixed end date limitation. This allows users to access and view calendar events further into the future.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->