### PR TITLE
fixed out of range focusDay bug in calendar

### DIFF
--- a/lib/screens/calendar/calendar_screen.dart
+++ b/lib/screens/calendar/calendar_screen.dart
@@ -369,9 +369,14 @@ Widget _buildCalendar() {
     child: Padding(
       padding: const EdgeInsets.all(8.0),
       child: TableCalendar(
-        firstDay: DateTime.utc(2024, 1, 1),
-        lastDay: DateTime.utc(2025, 12, 31),
+        // Dynamic date range from 100 years past to 100 years future
+        // This is lazy-loaded so it does not affect performance
+        firstDay: DateTime(DateTime.now().year - 100, 1, 1),
+        lastDay: DateTime(DateTime.now().year + 100, 12, 31),
         focusedDay: _focusedDay,
+        onPageChanged: (focusedDay) {
+          _focusedDay = focusedDay;
+        },
         calendarFormat: _calendarFormat,
         selectedDayPredicate: (day) => isSameDay(_selectedDay, day),
         eventLoader: _getEventsForDay,


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #132 


## 📝 Description
Hardcoded date range in calendar was causing errors when current date was going out of that range, fixed it by dynamically setting range relative to current date.

<!-- A clear and concise description of what this pull request does. -->
<!-- Include any context or background information if necessary. -->

## 🔧 Changes Made
- Removed hardcoded range
- Used dynamic range setting, 10 years from the current date of user.

<!-- List the changes you made in this pull request. -->
<!-- For example:
- Fixed a bug in the login flow.
- Added a new feature for user profile customization.
- Updated documentation for API endpoints.
-->
- Fixed a bug in calendar page which was causing error when current date was going out of range of hardcoded date.

## 📷 Screenshots or Visual Changes (if applicable)

<!-- Attach screenshots or GIFs to show visual changes, if any. -->
<!-- Drag and drop screenshots here or provide a description of visual updates. -->

<img width="688" height="1564" alt="image" src="https://github.com/user-attachments/assets/b4e18642-00ac-49d3-bfe6-ee522b494384" />


## 🤝 Collaboration

<!-- If you collaborated with someone on this pull request, mention their GitHub username or name here. -->
Collaborated with: `@username` (optional)


### ✅ Checklist

- [y ] I have read the contributing guidelines.
- [ y] I have added tests that prove my fix is effective or that my feature works.
- [y ] I have added necessary documentation (if applicable).
- [y ] Any dependent changes have been merged and published in downstream modules.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Calendar date range expanded to support ±100 years from the current year, replacing the previous fixed window.
  * Calendar navigation now properly tracks the currently visible month when scrolling through dates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->