### PR TITLE
Refactor: Move chat state ownership to ChatScreen

### DIFF
--- a/lib/screens/chat/chat_screen.dart
+++ b/lib/screens/chat/chat_screen.dart
@@ -10,7 +10,6 @@ import 'package:speech_to_text/speech_to_text.dart' as stt;
 
 class ChatScreen extends StatefulWidget {
   final Map<String, dynamic>? arguments;
-
   const ChatScreen({super.key, this.arguments});
 
   @override
@@ -21,70 +20,97 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
   final TextEditingController _messageController = TextEditingController();
   final ScrollController _scrollController = ScrollController();
   final List<ChatMessage> _messages = [];
-  bool _isProcessing = false;
-  bool _isListening = false; // toggles mic icon state
-  late AnimationController _waveformController;
-  late final stt.SpeechToText _speech;
-  bool _speechAvailable = false;
 
-  // Services
   final AIService _aiService = AIService();
   final SupabaseService _supabaseService = SupabaseService();
 
-  // Team members for assignment
   List<Map<String, dynamic>> _teamMembers = [];
   List<Map<String, dynamic>> _userTasks = [];
   List<Map<String, dynamic>> _userTickets = [];
 
+  bool _isProcessing = false;
+
+  // Speech
+  bool _isListening = false;
+  late AnimationController _waveformController;
+  late stt.SpeechToText _speech;
+  bool _speechAvailable = false;
+  bool _isListeningDialogOpen = false;
+
+  // Initial message safe handling
+  bool _servicesReady = false;
+  bool _initialMessageConsumed = false;
+  String? _pendingMessage;
+
   @override
   void initState() {
     super.initState();
+
     _waveformController = AnimationController(
       vsync: this,
       duration: const Duration(milliseconds: 1000),
     )..repeat();
 
-    _initializeServices();
     _initSpeech();
+    _initializeServices();
+  }
 
-    // Handle initial message if provided
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (widget.arguments != null &&
-          widget.arguments!.containsKey('initial_message') &&
-          widget.arguments!['initial_message'] is String) {
-        // Set a small delay to ensure services are initialized
-        Future.delayed(const Duration(milliseconds: 1000), () {
-          if (mounted) {
-            _messageController.text =
-                widget.arguments!['initial_message'] as String;
-            _sendMessage();
-          }
-        });
-      }
-    });
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+
+    if (_initialMessageConsumed) return;
+
+    final args = widget.arguments;
+    final initial = args?['initial_message'];
+
+    if (initial is String && initial.trim().isNotEmpty) {
+      _pendingMessage = initial.trim();
+      // Only mark consumed when a message was actually captured.
+      // If args are null/empty, stay open for late updates via didUpdateWidget.
+      _initialMessageConsumed = true;
+      _flushPendingMessageIfPossible();
+    }
+  }
+
+  @override
+  void didUpdateWidget(covariant ChatScreen oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    // Handle late-provided initial_message (e.g. HomeScreen rebuilds with
+    // _chatArgs after the first frame). Without this, the message would be
+    // silently dropped.
+    if (_initialMessageConsumed) return;
+
+    final args = widget.arguments;
+    final initial = args?['initial_message'];
+
+    if (initial is String && initial.trim().isNotEmpty) {
+      _pendingMessage = initial.trim();
+      _initialMessageConsumed = true;
+      _flushPendingMessageIfPossible();
+    }
   }
 
   Future<void> _initSpeech() async {
     _speech = stt.SpeechToText();
     _speechAvailable = await _speech.initialize(
       onStatus: (status) {
+        if (!mounted) return;
         if (status == 'done' || status == 'notListening') {
-          if (mounted) {
-            setState(() => _isListening = false);
-            // Dismiss dialog if open
-            if (Navigator.of(context).canPop()) {
-              Navigator.of(context).pop();
-            }
+          setState(() => _isListening = false);
+          if (_isListeningDialogOpen && Navigator.of(context).canPop()) {
+            Navigator.of(context).pop();
+            _isListeningDialogOpen = false;
           }
         }
       },
       onError: (error) {
+        if (!mounted) return;
         setState(() => _isListening = false);
-        if (mounted) {
-          setState(() => _isListening = false);
-          if (Navigator.of(context).canPop()) {
-            Navigator.of(context).pop();
-          }
+        if (_isListeningDialogOpen && Navigator.of(context).canPop()) {
+          Navigator.of(context).pop();
+          _isListeningDialogOpen = false;
         }
       },
     );
@@ -94,46 +120,43 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
 
   Future<void> _initializeServices() async {
     try {
-      if (!_aiService.isInitialized) {
-        await _aiService.initialize();
-      }
-
-      if (!_supabaseService.isInitialized) {
-        await _supabaseService.initialize();
-      }
+      if (!_aiService.isInitialized) await _aiService.initialize();
+      if (!_supabaseService.isInitialized) await _supabaseService.initialize();
 
       if (_supabaseService.isInitialized) {
         final userProfile = await _supabaseService.getCurrentUserProfile();
         if (userProfile != null && userProfile['team_id'] != null) {
           await _loadTeamMembers(userProfile['team_id']);
-
           await _loadUserTasksAndTickets();
         }
       }
 
+      if (!mounted) return;
+
       setState(() {
         _messages.add(
           ChatMessage(
-            text:
-                "Hello! I'm Ell-ena, your AI assistant. How can I help you today?",
+            text: "Hello! I'm Ell-ena, your AI assistant. How can I help you today?",
             isUser: false,
             timestamp: DateTime.now(),
           ),
         );
       });
+
+      _servicesReady = true;
+      _flushPendingMessageIfPossible();
     } catch (e) {
       debugPrint('Error initializing services: $e');
+      _servicesReady = true;
+      _flushPendingMessageIfPossible();
     }
   }
 
   Future<void> _loadTeamMembers(String teamId) async {
     try {
       final members = await _supabaseService.getTeamMembers(teamId);
-      if (mounted) {
-        setState(() {
-          _teamMembers = members;
-        });
-      }
+      if (!mounted) return;
+      setState(() => _teamMembers = members);
     } catch (e) {
       debugPrint('Error loading team members: $e');
     }
@@ -142,164 +165,99 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
   Future<void> _loadUserTasksAndTickets() async {
     try {
       final tasks = await _supabaseService.getTasks(filterByAssignment: true);
-
-      final tickets =
-          await _supabaseService.getTickets(filterByAssignment: true);
-
-      if (mounted) {
-        setState(() {
-          _userTasks = tasks;
-          _userTickets = tickets;
-        });
-      }
+      final tickets = await _supabaseService.getTickets(filterByAssignment: true);
+      if (!mounted) return;
+      setState(() {
+        _userTasks = tasks;
+        _userTickets = tickets;
+      });
     } catch (e) {
-      debugPrint('Error loading user tasks and tickets: $e');
+      debugPrint('Error loading tasks/tickets: $e');
     }
   }
 
-  @override
-  void dispose() {
-    _messageController.dispose();
-    _scrollController.dispose();
-    _waveformController.dispose();
-    if (_speechAvailable && _speech.isListening) {
-      _speech.stop();
-    }
-    super.dispose();
-  }
+  // --- UUID and team member resolution helpers ---
+  // Extracted to avoid duplication across _createTask, _createTicket,
+  // _queryTasks, _queryTickets, and _modifyItem.
 
-  // Build the listening animation dialog
-  Widget _buildListeningDialog() {
-    final colorScheme = Theme.of(context).colorScheme;
-    return Dialog(
-      backgroundColor: Colors.transparent,
-      elevation: 0,
-      child: Container(
-        width: 200,
-        height: 200,
-        padding: const EdgeInsets.all(20),
-        decoration: BoxDecoration(
-          color: colorScheme.surface,
-          borderRadius: BorderRadius.circular(20),
-          boxShadow: [
-            BoxShadow(
-              color: colorScheme.shadow.withOpacity(0.3),
-              blurRadius: 10,
-              spreadRadius: 2,
-            ),
-          ],
-        ),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            // Sound wave animation
-            Flexible(
-              child: FittedBox(
-                fit: BoxFit.contain,
-                child: AnimatedBuilder(
-                  animation: _waveformController,
-                  builder: (context, child) {
-                    return Container(
-                      height: 100,
-                      width: 100,
-                      decoration: BoxDecoration(
-                        shape: BoxShape.circle,
-                        color: Colors.green.withOpacity(0.1),
-                      ),
-                      child: Stack(
-                        alignment: Alignment.center,
-                        children: [
-                          // Outer ripple
-                          Container(
-                            width: 100 * _waveformController.value,
-                            height: 100 * _waveformController.value,
-                            decoration: BoxDecoration(
-                              shape: BoxShape.circle,
-                              color: Colors.green.withOpacity(
-                                  0.2 * (1 - _waveformController.value)),
-                            ),
-                          ),
-                          // Middle ripple
-                          Container(
-                            width: 70 * _waveformController.value,
-                            height: 70 * _waveformController.value,
-                            decoration: BoxDecoration(
-                              shape: BoxShape.circle,
-                              color: Colors.green.withOpacity(
-                                  0.3 * (1 - _waveformController.value)),
-                            ),
-                          ),
-                          // Inner circle with mic icon
-                          Container(
-                            width: 50,
-                            height: 50,
-                            decoration: const BoxDecoration(
-                              shape: BoxShape.circle,
-                              color: Colors.green,
-                            ),
-                            child: const Icon(
-                              Icons.mic,
-                              color: Colors.white,
-                              size: 24,
-                            ),
-                          ),
-                        ],
-                      ),
-                    );
-                  },
-                ),
-              ),
-            ),
-            const SizedBox(height: 20),
-            Text(
-              'Listening...',
-              style: TextStyle(
-                color: colorScheme.onSurface,
-                fontSize: 18,
-                fontWeight: FontWeight.bold,
-              ),
-            ),
-            const SizedBox(height: 10),
-            Text(
-              'Tap anywhere to cancel',
-              style: TextStyle(
-                color: colorScheme.onSurfaceVariant,
-                fontSize: 12,
-              ),
-            ),
-          ],
-        ),
-      ),
+  bool _isUuid(String value) => RegExp(
+        r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$',
+        caseSensitive: false,
+      ).hasMatch(value);
+
+  String? _resolveUserId(String assignedTo) {
+    if (_isUuid(assignedTo)) return assignedTo;
+
+    // Exact match
+    var match = _teamMembers.firstWhere(
+      (m) => m['full_name'].toString().toLowerCase() == assignedTo.toLowerCase(),
+      orElse: () => {},
     );
+    if (match.isNotEmpty && match['id'] != null) return match['id'];
+
+    // Partial match
+    match = _teamMembers.firstWhere(
+      (m) => m['full_name'].toString().toLowerCase().contains(assignedTo.toLowerCase()),
+      orElse: () => {},
+    );
+    if (match.isNotEmpty && match['id'] != null) return match['id'];
+
+    // First name match
+    for (final member in _teamMembers) {
+      final firstName = member['full_name'].toString().toLowerCase().split(' ').first;
+      if (firstName == assignedTo.toLowerCase()) return member['id'];
+    }
+
+    debugPrint('Could not find team member: $assignedTo');
+    return null;
+  }
+
+  /// Safe: sends pending message only if services ready and not currently processing
+  void _flushPendingMessageIfPossible() {
+    if (!_servicesReady) return;
+    if (_isProcessing) return;
+    final msg = _pendingMessage?.trim();
+    if (msg == null || msg.isEmpty) return;
+
+    _pendingMessage = null;
+    _messageController.text = msg;
+    _sendMessage();
   }
 
   void _sendMessage() async {
-    if (_messageController.text.trim().isEmpty) return;
-    if (_isProcessing) return;
+    final text = _messageController.text.trim();
+    if (text.isEmpty) return;
+    if (_isProcessing) {
+      _pendingMessage = text;
+      return;
+    }
 
-    final userMessage = _messageController.text;
+    final userMessage = text;
     _messageController.clear();
 
+    if (!mounted) return;
     setState(() {
-      _messages.add(
-        ChatMessage(text: userMessage, isUser: true, timestamp: DateTime.now()),
-      );
+      _messages.add(ChatMessage(
+        text: userMessage,
+        isUser: true,
+        timestamp: DateTime.now(),
+      ));
       _isProcessing = true;
     });
 
     _scrollToBottom();
 
     try {
-      final chatHistory = _getChatHistoryForAI();
-
+      final history = _getChatHistoryForAI();
       final response = await _aiService.generateChatResponse(
         userMessage,
-        chatHistory,
+        history,
         _teamMembers,
         userTasks: _userTasks,
         userTickets: _userTickets,
       );
+
+      if (!mounted) return;
 
       if (response['type'] == 'function_call') {
         await _handleFunctionCall(
@@ -309,43 +267,38 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
         );
       } else {
         setState(() {
-          _messages.add(
-            ChatMessage(
-              text: response['content'],
-              isUser: false,
-              timestamp: DateTime.now(),
-            ),
-          );
+          _messages.add(ChatMessage(
+            text: response['content'],
+            isUser: false,
+            timestamp: DateTime.now(),
+          ));
           _isProcessing = false;
         });
       }
     } catch (e) {
       debugPrint('Error sending message: $e');
+      if (!mounted) return;
       setState(() {
-        _messages.add(
-          ChatMessage(
-            text: "Sorry, I encountered an error. Please try again later.",
-            isUser: false,
-            timestamp: DateTime.now(),
-          ),
-        );
+        _messages.add(ChatMessage(
+          text: "Sorry, I encountered an error. Please try again later.",
+          isUser: false,
+          timestamp: DateTime.now(),
+        ));
         _isProcessing = false;
       });
     }
 
     _scrollToBottom();
+    _flushPendingMessageIfPossible();
   }
 
   List<Map<String, String>> _getChatHistoryForAI() {
-    final recentMessages = _messages.length > 10
+    final recent = _messages.length > 10
         ? _messages.sublist(_messages.length - 10)
         : _messages;
-
-    return recentMessages.map((message) {
-      return {
-        "role": message.isUser ? "user" : "assistant",
-        "content": message.text,
-      };
+    return recent.map((m) => {
+      "role": m.isUser ? "user" : "assistant",
+      "content": m.text,
     }).toList();
   }
 
@@ -354,14 +307,14 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
     Map<String, dynamic> arguments,
     String rawResponse,
   ) async {
+    if (!mounted) return;
+
     setState(() {
-      _messages.add(
-        ChatMessage(
-          text: "I'll help you with that. Let me process your request...",
-          isUser: false,
-          timestamp: DateTime.now(),
-        ),
-      );
+      _messages.add(ChatMessage(
+        text: "I'll help you with that. Let me process your request...",
+        isUser: false,
+        timestamp: DateTime.now(),
+      ));
     });
 
     _scrollToBottom();
@@ -372,7 +325,6 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
         'error': 'Function not implemented'
       };
 
-      // Execute the appropriate function based on the function name
       switch (functionName) {
         case 'create_task':
           result = await _createTask(arguments);
@@ -396,7 +348,6 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
           result = {'success': false, 'error': 'Unknown function'};
       }
 
-      // Get a user-friendly response from the AI
       final responseMessage = await _aiService.handleToolResponse(
         functionName: functionName,
         arguments: arguments,
@@ -404,61 +355,52 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
         result: result,
       );
 
-      // Add the response to the chat
+      if (!mounted) return;
       setState(() {
-        _messages.add(
-          ChatMessage(
-            text: responseMessage,
-            isUser: false,
-            timestamp: DateTime.now(),
-          ),
-        );
+        _messages.add(ChatMessage(
+          text: responseMessage,
+          isUser: false,
+          timestamp: DateTime.now(),
+        ));
 
-        // Add card if successful for creation functions
         if (result['success'] == true &&
             (functionName == 'create_task' ||
                 functionName == 'create_ticket' ||
                 functionName == 'create_meeting')) {
-          _messages.add(
-            ChatMessage(
-              text: _getCardText(functionName, arguments, result),
-              isUser: false,
-              timestamp: DateTime.now(),
-              isCard: true,
-              cardType: _getCardType(functionName),
-              cardData: result,
-            ),
-          );
+          _messages.add(ChatMessage(
+            text: _getCardText(functionName, arguments, result),
+            isUser: false,
+            timestamp: DateTime.now(),
+            isCard: true,
+            cardType: _getCardType(functionName),
+            cardData: result,
+          ));
         }
 
         _isProcessing = false;
       });
 
-      // Refresh tasks and tickets if we just queried them
       if (functionName == 'query_tasks' || functionName == 'query_tickets') {
         _loadUserTasksAndTickets();
       }
     } catch (e) {
       debugPrint('Error handling function call: $e');
+      if (!mounted) return;
       setState(() {
-        _messages.add(
-          ChatMessage(
-            text:
-                "Sorry, I encountered an error while processing your request.",
-            isUser: false,
-            timestamp: DateTime.now(),
-          ),
-        );
+        _messages.add(ChatMessage(
+          text: "Sorry, I encountered an error while processing your request.",
+          isUser: false,
+          timestamp: DateTime.now(),
+        ));
         _isProcessing = false;
       });
     }
 
     _scrollToBottom();
+    _flushPendingMessageIfPossible();
   }
 
-  // Create a task using the Supabase service
-  Future<Map<String, dynamic>> _createTask(
-      Map<String, dynamic> arguments) async {
+  Future<Map<String, dynamic>> _createTask(Map<String, dynamic> arguments) async {
     try {
       if (!_supabaseService.isInitialized) {
         return {'success': false, 'error': 'Service not initialized'};
@@ -467,62 +409,29 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
       final title = arguments['title'] as String;
       final description = arguments['description'] as String?;
 
-      // Parse due date if provided
       DateTime? dueDate;
       if (arguments['due_date'] != null) {
-        try {
-          dueDate = DateTime.parse(arguments['due_date']);
-        } catch (e) {
-          debugPrint('Error parsing due date: $e');
-        }
+        try { dueDate = DateTime.parse(arguments['due_date']); } catch (_) {}
       }
 
-      // Get assigned user ID if provided
       String? assignedToUserId;
       final assignedTo = arguments['assigned_to'] as String?;
-
       if (assignedTo != null && assignedTo.isNotEmpty) {
-        // Check if the value is already a valid UUID
-        final uuidPattern = RegExp(
-            r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$',
-            caseSensitive: false);
-
-        if (uuidPattern.hasMatch(assignedTo)) {
-          // It's already a UUID
-          assignedToUserId = assignedTo;
-        } else {
-          // Try to find the user by name
-          final matchingMember = _teamMembers.firstWhere(
-            (member) =>
-                member['full_name'].toString().toLowerCase() ==
-                assignedTo.toLowerCase(),
-            orElse: () => {},
-          );
-
-          if (matchingMember.isNotEmpty && matchingMember['id'] != null) {
-            assignedToUserId = matchingMember['id'];
-          }
-        }
+        assignedToUserId = _resolveUserId(assignedTo);
       }
 
-      // Create the task
-      final result = await _supabaseService.createTask(
+      return await _supabaseService.createTask(
         title: title,
         description: description,
         dueDate: dueDate,
         assignedToUserId: assignedToUserId,
       );
-
-      return result;
     } catch (e) {
-      debugPrint('Error creating task: $e');
       return {'success': false, 'error': e.toString()};
     }
   }
 
-  // Create a ticket using the Supabase service
-  Future<Map<String, dynamic>> _createTicket(
-      Map<String, dynamic> arguments) async {
+  Future<Map<String, dynamic>> _createTicket(Map<String, dynamic> arguments) async {
     try {
       if (!_supabaseService.isInitialized) {
         return {'success': false, 'error': 'Service not initialized'};
@@ -533,53 +442,25 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
       final priority = arguments['priority'] as String;
       final category = arguments['category'] as String;
 
-      // Get assigned user ID if provided
       String? assignedToUserId;
       final assignedTo = arguments['assigned_to'] as String?;
-
       if (assignedTo != null && assignedTo.isNotEmpty) {
-        // Check if the value is already a valid UUID
-        final uuidPattern = RegExp(
-            r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$',
-            caseSensitive: false);
-
-        if (uuidPattern.hasMatch(assignedTo)) {
-          // It's already a UUID
-          assignedToUserId = assignedTo;
-        } else {
-          // Try to find the user by name
-          final matchingMember = _teamMembers.firstWhere(
-            (member) =>
-                member['full_name'].toString().toLowerCase() ==
-                assignedTo.toLowerCase(),
-            orElse: () => {},
-          );
-
-          if (matchingMember.isNotEmpty && matchingMember['id'] != null) {
-            assignedToUserId = matchingMember['id'];
-          }
-        }
+        assignedToUserId = _resolveUserId(assignedTo);
       }
 
-      // Create the ticket
-      final result = await _supabaseService.createTicket(
+      return await _supabaseService.createTicket(
         title: title,
         description: description,
         priority: priority,
         category: category,
         assignedToUserId: assignedToUserId,
       );
-
-      return result;
     } catch (e) {
-      debugPrint('Error creating ticket: $e');
       return {'success': false, 'error': e.toString()};
     }
   }
 
-  // Create a meeting using the Supabase service
-  Future<Map<String, dynamic>> _createMeeting(
-      Map<String, dynamic> arguments) async {
+  Future<Map<String, dynamic>> _createMeeting(Map<String, dynamic> arguments) async {
     try {
       if (!_supabaseService.isInitialized) {
         return {'success': false, 'error': 'Service not initialized'};
@@ -587,36 +468,27 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
 
       final title = arguments['title'] as String;
       final description = arguments['description'] as String?;
+      final meetingUrl = arguments['meeting_url'] as String?;
 
-      // Parse meeting date
       DateTime meetingDate;
       try {
         meetingDate = DateTime.parse(arguments['meeting_date']);
-      } catch (e) {
-        debugPrint('Error parsing meeting date: $e');
+      } catch (_) {
         return {'success': false, 'error': 'Invalid meeting date format'};
       }
 
-      final meetingUrl = arguments['meeting_url'] as String?;
-
-      // Create the meeting
-      final result = await _supabaseService.createMeeting(
+      return await _supabaseService.createMeeting(
         title: title,
         description: description,
         meetingDate: meetingDate,
         meetingUrl: meetingUrl,
       );
-
-      return result;
     } catch (e) {
-      debugPrint('Error creating meeting: $e');
       return {'success': false, 'error': e.toString()};
     }
   }
 
-  // Query tasks based on filters
-  Future<Map<String, dynamic>> _queryTasks(
-      Map<String, dynamic> arguments) async {
+  Future<Map<String, dynamic>> _queryTasks(Map<String, dynamic> arguments) async {
     try {
       if (!_supabaseService.isInitialized) {
         return {'success': false, 'error': 'Service not initialized'};
@@ -625,79 +497,21 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
       final status = arguments['status'] as String?;
       final dueDate = arguments['due_date'] as String?;
       final assignedToMe = arguments['assigned_to_me'] as bool? ?? false;
-      final assignedToTeamMember =
-          arguments['assigned_to_team_member'] as String?;
+      final assignedToTeamMember = arguments['assigned_to_team_member'] as String?;
 
-      // Find team member ID if name was provided
       String? teamMemberId;
       if (assignedToTeamMember != null && assignedToTeamMember.isNotEmpty) {
-        // Check if it's already a UUID
-        final uuidPattern = RegExp(
-            r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$',
-            caseSensitive: false);
-
-        if (uuidPattern.hasMatch(assignedToTeamMember)) {
-          teamMemberId = assignedToTeamMember;
-        } else {
-          // Try to find by name - more flexible matching
-          // First try exact match
-          var matchingMember = _teamMembers.firstWhere(
-            (member) =>
-                member['full_name'].toString().toLowerCase() ==
-                assignedToTeamMember.toLowerCase(),
-            orElse: () => {},
-          );
-
-          // If no exact match, try partial match
-          if (matchingMember.isEmpty) {
-            matchingMember = _teamMembers.firstWhere(
-              (member) => member['full_name']
-                  .toString()
-                  .toLowerCase()
-                  .contains(assignedToTeamMember.toLowerCase()),
-              orElse: () => {},
-            );
-          }
-
-          // Try matching first name only
-          if (matchingMember.isEmpty) {
-            for (var member in _teamMembers) {
-              final fullName = member['full_name'].toString().toLowerCase();
-              final firstName = fullName.split(' ').first;
-              if (firstName == assignedToTeamMember.toLowerCase()) {
-                matchingMember = member;
-                break;
-              }
-            }
-          }
-
-          if (matchingMember.isNotEmpty && matchingMember['id'] != null) {
-            teamMemberId = matchingMember['id'];
-            debugPrint(
-                'Found team member: ${matchingMember['full_name']} with ID: $teamMemberId');
-          } else {
-            debugPrint(
-                'Could not find team member with name: $assignedToTeamMember');
-            debugPrint(
-                'Available team members: ${_teamMembers.map((m) => m['full_name']).join(', ')}');
-          }
-        }
+        teamMemberId = _resolveUserId(assignedToTeamMember);
       }
 
-      // Get tasks with filters
       List<Map<String, dynamic>> tasks;
-
       if (teamMemberId != null) {
-        // For team member queries, we need to manually filter results
         tasks = await _supabaseService.getTasks(
-          filterByAssignment: false, // Don't filter by current user
+          filterByAssignment: false,
           filterByStatus: status != null && status != 'all' ? status : null,
           filterByDueDate: dueDate,
         );
-
-        // Filter by assigned team member
-        tasks =
-            tasks.where((task) => task['assigned_to'] == teamMemberId).toList();
+        tasks = tasks.where((t) => t['assigned_to'] == teamMemberId).toList();
       } else {
         tasks = await _supabaseService.getTasks(
           filterByAssignment: assignedToMe,
@@ -706,27 +520,14 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
         );
       }
 
-      // Update local cache
-      if (mounted) {
-        setState(() {
-          _userTasks = tasks;
-        });
-      }
-
-      return {
-        'success': true,
-        'tasks': tasks,
-        'count': tasks.length,
-      };
+      if (mounted) setState(() => _userTasks = tasks);
+      return {'success': true, 'tasks': tasks, 'count': tasks.length};
     } catch (e) {
-      debugPrint('Error querying tasks: $e');
       return {'success': false, 'error': e.toString()};
     }
   }
 
-  // Query tickets based on filters
-  Future<Map<String, dynamic>> _queryTickets(
-      Map<String, dynamic> arguments) async {
+  Future<Map<String, dynamic>> _queryTickets(Map<String, dynamic> arguments) async {
     try {
       if (!_supabaseService.isInitialized) {
         return {'success': false, 'error': 'Service not initialized'};
@@ -735,111 +536,37 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
       final status = arguments['status'] as String?;
       final priority = arguments['priority'] as String?;
       final assignedToMe = arguments['assigned_to_me'] as bool? ?? false;
-      final assignedToTeamMember =
-          arguments['assigned_to_team_member'] as String?;
+      final assignedToTeamMember = arguments['assigned_to_team_member'] as String?;
 
-      // Find team member ID if name was provided
       String? teamMemberId;
       if (assignedToTeamMember != null && assignedToTeamMember.isNotEmpty) {
-        // Check if it's already a UUID
-        final uuidPattern = RegExp(
-            r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$',
-            caseSensitive: false);
-
-        if (uuidPattern.hasMatch(assignedToTeamMember)) {
-          teamMemberId = assignedToTeamMember;
-        } else {
-          // Try to find by name - more flexible matching
-          // First try exact match
-          var matchingMember = _teamMembers.firstWhere(
-            (member) =>
-                member['full_name'].toString().toLowerCase() ==
-                assignedToTeamMember.toLowerCase(),
-            orElse: () => {},
-          );
-
-          // If no exact match, try partial match
-          if (matchingMember.isEmpty) {
-            matchingMember = _teamMembers.firstWhere(
-              (member) => member['full_name']
-                  .toString()
-                  .toLowerCase()
-                  .contains(assignedToTeamMember.toLowerCase()),
-              orElse: () => {},
-            );
-          }
-
-          // Try matching first name only
-          if (matchingMember.isEmpty) {
-            for (var member in _teamMembers) {
-              final fullName = member['full_name'].toString().toLowerCase();
-              final firstName = fullName.split(' ').first;
-              if (firstName == assignedToTeamMember.toLowerCase()) {
-                matchingMember = member;
-                break;
-              }
-            }
-          }
-
-          if (matchingMember.isNotEmpty && matchingMember['id'] != null) {
-            teamMemberId = matchingMember['id'];
-            debugPrint(
-                'Found team member: ${matchingMember['full_name']} with ID: $teamMemberId');
-          } else {
-            debugPrint(
-                'Could not find team member with name: $assignedToTeamMember');
-            debugPrint(
-                'Available team members: ${_teamMembers.map((m) => m['full_name']).join(', ')}');
-          }
-        }
+        teamMemberId = _resolveUserId(assignedToTeamMember);
       }
 
-      // Get tickets with filters
       List<Map<String, dynamic>> tickets;
-
       if (teamMemberId != null) {
-        // For team member queries, we need to manually filter results
         tickets = await _supabaseService.getTickets(
-          filterByAssignment: false, // Don't filter by current user
+          filterByAssignment: false,
           filterByStatus: status != null && status != 'all' ? status : null,
-          filterByPriority:
-              priority != null && priority != 'all' ? priority : null,
+          filterByPriority: priority != null && priority != 'all' ? priority : null,
         );
-
-        // Filter by assigned team member
-        tickets = tickets
-            .where((ticket) => ticket['assigned_to'] == teamMemberId)
-            .toList();
+        tickets = tickets.where((t) => t['assigned_to'] == teamMemberId).toList();
       } else {
         tickets = await _supabaseService.getTickets(
           filterByAssignment: assignedToMe,
           filterByStatus: status != null && status != 'all' ? status : null,
-          filterByPriority:
-              priority != null && priority != 'all' ? priority : null,
+          filterByPriority: priority != null && priority != 'all' ? priority : null,
         );
       }
 
-      // Update local cache
-      if (mounted) {
-        setState(() {
-          _userTickets = tickets;
-        });
-      }
-
-      return {
-        'success': true,
-        'tickets': tickets,
-        'count': tickets.length,
-      };
+      if (mounted) setState(() => _userTickets = tickets);
+      return {'success': true, 'tickets': tickets, 'count': tickets.length};
     } catch (e) {
-      debugPrint('Error querying tickets: $e');
       return {'success': false, 'error': e.toString()};
     }
   }
 
-  // Modify an existing task, ticket, or meeting
-  Future<Map<String, dynamic>> _modifyItem(
-      Map<String, dynamic> arguments) async {
+  Future<Map<String, dynamic>> _modifyItem(Map<String, dynamic> arguments) async {
     try {
       if (!_supabaseService.isInitialized) {
         return {'success': false, 'error': 'Service not initialized'};
@@ -847,139 +574,25 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
 
       final itemType = arguments['item_type'] as String;
       final itemId = arguments['item_id'] as String;
-      final title = arguments['title'] as String?;
-      final description = arguments['description'] as String?;
       final status = arguments['status'] as String?;
-      final dueDate = arguments['due_date'] as String?;
       final priority = arguments['priority'] as String?;
       final meetingDate = arguments['meeting_date'] as String?;
-      final assignedTo = arguments['assigned_to'] as String?;
+      final title = arguments['title'] as String?;
+      final description = arguments['description'] as String?;
 
-      // Get assigned user ID if provided
-      String? assignedToUserId;
-      if (assignedTo != null && assignedTo.isNotEmpty) {
-        // Check if the value is already a valid UUID
-        final uuidPattern = RegExp(
-            r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$',
-            caseSensitive: false);
-
-        if (uuidPattern.hasMatch(assignedTo)) {
-          // It's already a UUID
-          assignedToUserId = assignedTo;
-        } else {
-          // Try to find by name - more flexible matching
-          // First try exact match
-          var matchingMember = _teamMembers.firstWhere(
-            (member) =>
-                member['full_name'].toString().toLowerCase() ==
-                assignedTo.toLowerCase(),
-            orElse: () => {},
-          );
-
-          // If no exact match, try partial match
-          if (matchingMember.isEmpty) {
-            matchingMember = _teamMembers.firstWhere(
-              (member) => member['full_name']
-                  .toString()
-                  .toLowerCase()
-                  .contains(assignedTo.toLowerCase()),
-              orElse: () => {},
-            );
-          }
-
-          // Try matching first name only
-          if (matchingMember.isEmpty) {
-            for (var member in _teamMembers) {
-              final fullName = member['full_name'].toString().toLowerCase();
-              final firstName = fullName.split(' ').first;
-              if (firstName == assignedTo.toLowerCase()) {
-                matchingMember = member;
-                break;
-              }
-            }
-          }
-
-          if (matchingMember.isNotEmpty && matchingMember['id'] != null) {
-            assignedToUserId = matchingMember['id'];
-            debugPrint(
-                'Found team member: ${matchingMember['full_name']} with ID: $assignedToUserId');
-          } else {
-            debugPrint('Could not find team member with name: $assignedTo');
-            debugPrint(
-                'Available team members: ${_teamMembers.map((m) => m['full_name']).join(', ')}');
-          }
-        }
-      }
-
-      // Prepare update data based on item type
-      Map<String, dynamic> updateData = {};
-
-      if (title != null) updateData['title'] = title;
-      if (description != null) updateData['description'] = description;
-      if (status != null) updateData['status'] = status;
-      if (assignedToUserId != null)
-        updateData['assigned_to'] = assignedToUserId;
-
-      // Add type-specific fields
-      switch (itemType) {
-        case 'task':
-          if (dueDate != null) {
-            try {
-              final parsedDate = DateTime.parse(dueDate);
-              updateData['due_date'] = parsedDate.toIso8601String();
-            } catch (e) {
-              return {'success': false, 'error': 'Invalid due date format'};
-            }
-          }
-          break;
-
-        case 'ticket':
-          if (priority != null) updateData['priority'] = priority;
-          break;
-
-        case 'meeting':
-          if (meetingDate != null) {
-            try {
-              final parsedDate = DateTime.parse(meetingDate);
-              updateData['meeting_date'] = parsedDate.toIso8601String();
-            } catch (e) {
-              return {'success': false, 'error': 'Invalid meeting date format'};
-            }
-          }
-          break;
-
-        default:
-          return {'success': false, 'error': 'Invalid item type'};
-      }
-
-      if (updateData.isEmpty) {
-        return {'success': false, 'error': 'No changes specified'};
-      }
-
-      // Update the item in the database
-      Map<String, dynamic> result = {
-        'success': false,
-        'error': 'No changes made'
-      };
+      Map<String, dynamic> result = {'success': false, 'error': 'No changes made'};
 
       switch (itemType) {
         case 'task':
-          // For tasks, we need to handle different update methods based on what's changing
           if (status != null) {
             result = await _supabaseService.updateTaskStatus(
               taskId: itemId,
               status: status,
             );
           }
-
-          // Handle other task updates as needed
-          // Note: This is a simplified implementation - for a complete solution,
-          // you would need to add methods to SupabaseService to handle all fields
-
           break;
 
         case 'ticket':
-          // For tickets, we need to handle different update methods based on what's changing
           if (status != null) {
             result = await _supabaseService.updateTicketStatus(
               ticketId: itemId,
@@ -991,18 +604,12 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
               priority: priority,
             );
           }
-
-          // Handle other ticket updates as needed
-
           break;
 
         case 'meeting':
-          // For meetings, we need to get the current meeting details first
-          final meetingDetails =
-              await _supabaseService.getMeetingDetails(itemId);
+          final meetingDetails = await _supabaseService.getMeetingDetails(itemId);
           if (meetingDetails != null) {
-            // Update with new values, keeping existing ones if not provided
-            final updatedMeeting = await _supabaseService.updateMeeting(
+            result = await _supabaseService.updateMeeting(
               meetingId: itemId,
               title: title ?? meetingDetails['title'],
               description: description ?? meetingDetails['description'],
@@ -1011,8 +618,6 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
                   : DateTime.parse(meetingDetails['meeting_date']),
               meetingUrl: meetingDetails['meeting_url'],
             );
-
-            result = updatedMeeting;
           }
           break;
 
@@ -1020,40 +625,29 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
           return {'success': false, 'error': 'Invalid item type'};
       }
 
-      if (result['success'] == true) {
-        _loadUserTasksAndTickets();
-      }
-
+      if (result['success'] == true) _loadUserTasksAndTickets();
       return result;
     } catch (e) {
-      debugPrint('Error modifying item: $e');
       return {'success': false, 'error': e.toString()};
     }
   }
 
   String _getCardType(String functionName) {
     switch (functionName) {
-      case 'create_task':
-        return 'task';
-      case 'create_ticket':
-        return 'ticket';
-      case 'create_meeting':
-        return 'meeting';
-      default:
-        return 'generic';
+      case 'create_task': return 'task';
+      case 'create_ticket': return 'ticket';
+      case 'create_meeting': return 'meeting';
+      default: return 'generic';
     }
   }
 
-  // Get card text based on function name and arguments
   String _getCardText(String functionName, Map<String, dynamic> arguments,
       Map<String, dynamic> result) {
     switch (functionName) {
       case 'create_task':
-        return arguments['title'] ?? 'New Task';
       case 'create_ticket':
-        return arguments['title'] ?? 'New Ticket';
       case 'create_meeting':
-        return arguments['title'] ?? 'New Meeting';
+        return arguments['title'] ?? 'Created';
       default:
         return 'Item created';
     }
@@ -1061,69 +655,13 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
 
   void _scrollToBottom() {
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (_scrollController.hasClients) {
-        _scrollController.animateTo(
-          _scrollController.position.maxScrollExtent,
-          duration: const Duration(milliseconds: 300),
-          curve: Curves.easeOut,
-        );
-      }
-    });
-  }
-
-  void _navigateToItem(ChatMessage message) {
-    try {
-      if (message.cardType == 'task' &&
-          message.cardData != null &&
-          message.cardData!['task'] != null) {
-        // Navigate to task detail screen
-        Navigator.push(
-          context,
-          MaterialPageRoute(
-            builder: (context) =>
-                TaskDetailScreen(taskId: message.cardData!['task']['id']),
-          ),
-        );
-      } else if (message.cardType == 'ticket' &&
-          message.cardData != null &&
-          message.cardData!['ticket'] != null) {
-        // Navigate to ticket detail screen
-        Navigator.push(
-          context,
-          MaterialPageRoute(
-            builder: (context) =>
-                TicketDetailScreen(ticketId: message.cardData!['ticket']['id']),
-          ),
-        );
-      } else if (message.cardType == 'meeting' &&
-          message.cardData != null &&
-          message.cardData!['meeting'] != null) {
-        // Navigate to meeting detail screen
-        Navigator.push(
-          context,
-          MaterialPageRoute(
-            builder: (context) => MeetingDetailScreen(
-                meetingId: message.cardData!['meeting']['id']),
-          ),
-        );
-      } else {
-        // Show error message
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(
-            content: Text('Could not navigate to the item. Details missing.'),
-            backgroundColor: Colors.red,
-          ),
-        );
-      }
-    } catch (e) {
-      debugPrint('Error navigating to item: $e');
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text('Navigation error: $e'),
-          backgroundColor: Colors.red,
-        ),
+      if (!_scrollController.hasClients) return;
+      _scrollController.animateTo(
+        _scrollController.position.maxScrollExtent,
+        duration: const Duration(milliseconds: 300),
+        curve: Curves.easeOut,
       );
-    }
+    });
   }
 
   Future<void> _toggleListening() async {
@@ -1134,41 +672,141 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
       );
       return;
     }
+
     if (_speech.isListening) {
       await _speech.stop();
+      if (!mounted) return;
       setState(() => _isListening = false);
       return;
     }
 
-    // Show the listening animation dialog
-    if (mounted) {
-      showDialog(
-        context: context,
-        barrierDismissible: true,
-        builder: (context) => _buildListeningDialog(),
-      ).then((_) {
-        // Stop listening if dialog was dismissed
-        if (_isListening && _speech.isListening) {
-          _speech.stop();
-          setState(() => _isListening = false);
-        }
-      });
-    }
+    if (!mounted) return;
 
     setState(() => _isListening = true);
+
+    _isListeningDialogOpen = true;
+    showDialog(
+      context: context,
+      barrierDismissible: true,
+      builder: (_) => _buildListeningDialog(),
+    ).then((_) async {
+      _isListeningDialogOpen = false;
+      if (_speech.isListening) await _speech.stop();
+      if (mounted) setState(() => _isListening = false);
+    });
+
     await _speech.listen(
       onResult: (result) {
-        setState(() {
-          _messageController.text = result.recognizedWords;
-        });
+        if (!mounted) return;
+        setState(() => _messageController.text = result.recognizedWords);
       },
       listenMode: stt.ListenMode.dictation,
       partialResults: true,
       cancelOnError: true,
-      onSoundLevelChange: (level) {
-        // You can use this to update animation intensity if needed
-      },
     );
+  }
+
+  Widget _buildListeningDialog() {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Dialog(
+      backgroundColor: Colors.transparent,
+      elevation: 0,
+      child: Container(
+        width: 200,
+        height: 200,
+        padding: const EdgeInsets.all(20),
+        decoration: BoxDecoration(
+          color: colorScheme.surface,
+          borderRadius: BorderRadius.circular(20),
+          boxShadow: [
+            BoxShadow(
+              color: colorScheme.shadow.withOpacity(0.3),
+              blurRadius: 10,
+              spreadRadius: 2,
+            ),
+          ],
+        ),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Flexible(
+              child: FittedBox(
+                fit: BoxFit.contain,
+                child: AnimatedBuilder(
+                  animation: _waveformController,
+                  builder: (context, child) {
+                    return Container(
+                      height: 100,
+                      width: 100,
+                      decoration: BoxDecoration(
+                        shape: BoxShape.circle,
+                        color: Colors.green.withOpacity(0.1),
+                      ),
+                      child: Stack(
+                        alignment: Alignment.center,
+                        children: [
+                          Container(
+                            width: 100 * _waveformController.value,
+                            height: 100 * _waveformController.value,
+                            decoration: BoxDecoration(
+                              shape: BoxShape.circle,
+                              color: Colors.green.withOpacity(
+                                  0.2 * (1 - _waveformController.value)),
+                            ),
+                          ),
+                          Container(
+                            width: 70 * _waveformController.value,
+                            height: 70 * _waveformController.value,
+                            decoration: BoxDecoration(
+                              shape: BoxShape.circle,
+                              color: Colors.green.withOpacity(
+                                  0.3 * (1 - _waveformController.value)),
+                            ),
+                          ),
+                          Container(
+                            width: 50,
+                            height: 50,
+                            decoration: const BoxDecoration(
+                              shape: BoxShape.circle,
+                              color: Colors.green,
+                            ),
+                            child: const Icon(Icons.mic,
+                                color: Colors.white, size: 24),
+                          ),
+                        ],
+                      ),
+                    );
+                  },
+                ),
+              ),
+            ),
+            const SizedBox(height: 20),
+            Text(
+              'Listening...',
+              style: TextStyle(
+                color: colorScheme.onSurface,
+                fontSize: 18,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            const SizedBox(height: 10),
+            Text(
+              'Tap anywhere to cancel',
+              style: TextStyle(color: colorScheme.onSurfaceVariant, fontSize: 12),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    _messageController.dispose();
+    _scrollController.dispose();
+    _waveformController.dispose();
+    if (_speechAvailable && _speech.isListening) _speech.stop();
+    super.dispose();
   }
 
   @override
@@ -1178,207 +816,252 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
       backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       body: Column(
         children: [
+          _buildHeader(colorScheme),
+          Expanded(child: _buildChatList(colorScheme)),
+          _buildInputBar(colorScheme),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildHeader(ColorScheme colorScheme) {
+    return Container(
+      padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 20),
+      decoration: BoxDecoration(
+        color: colorScheme.surface,
+        boxShadow: [
+          BoxShadow(
+            color: colorScheme.shadow.withOpacity(0.2),
+            offset: const Offset(0, 2),
+            blurRadius: 4,
+          ),
+        ],
+      ),
+      child: SafeArea(
+        bottom: false,
+        child: Row(
+          children: [
+            Container(
+              width: 40,
+              height: 40,
+              decoration: BoxDecoration(
+                color: Colors.green.withOpacity(0.2),
+                shape: BoxShape.circle,
+              ),
+              child: const Icon(Icons.smart_toy, color: Colors.green),
+            ),
+            const SizedBox(width: 12),
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  'Chat with Ell-ena',
+                  style: TextStyle(
+                    color: colorScheme.onSurface,
+                    fontSize: 18,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                Text(
+                  'Your AI Assistant',
+                  style: TextStyle(
+                      color: colorScheme.onSurfaceVariant, fontSize: 14),
+                ),
+              ],
+            ),
+            const Spacer(),
+            Container(
+              padding: const EdgeInsets.all(8),
+              decoration: BoxDecoration(
+                color: Colors.green.withOpacity(0.1),
+                shape: BoxShape.circle,
+              ),
+              child: const Icon(Icons.info_outline, color: Colors.green, size: 20),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildChatList(ColorScheme colorScheme) {
+    if (_messages.isEmpty) {
+      return Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(Icons.chat_bubble_outline,
+                size: 64, color: colorScheme.onSurfaceVariant),
+            const SizedBox(height: 16),
+            Text(
+              'Start a conversation with Ell-ena',
+              style: TextStyle(
+                  color: colorScheme.onSurfaceVariant, fontSize: 16),
+            ),
+          ],
+        ),
+      );
+    }
+
+    return ListView.builder(
+      controller: _scrollController,
+      padding: const EdgeInsets.all(16),
+      itemCount: _messages.length + (_isProcessing ? 1 : 0),
+      itemBuilder: (context, index) {
+        if (_isProcessing && index == _messages.length) {
+          return Align(
+            alignment: Alignment.centerLeft,
+            child: Container(
+              margin: const EdgeInsets.symmetric(vertical: 8),
+              padding:
+                  const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+              decoration: BoxDecoration(
+                color: colorScheme.surfaceVariant,
+                borderRadius: BorderRadius.circular(20),
+              ),
+              child: LoadingAnimationWidget.staggeredDotsWave(
+                color: Colors.green,
+                size: 24,
+              ),
+            ),
+          );
+        }
+
+        final message = _messages[index];
+        if (message.isCard == true) {
+          return _ItemCard(
+            message: message,
+            onViewItem: () => _navigateToItem(message),
+          );
+        }
+        return _ChatBubble(message: message);
+      },
+    );
+  }
+
+  Widget _buildInputBar(ColorScheme colorScheme) {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: colorScheme.surface,
+        borderRadius: const BorderRadius.only(
+          topLeft: Radius.circular(20),
+          topRight: Radius.circular(20),
+        ),
+      ),
+      child: Row(
+        children: [
+          Expanded(
+            child: Container(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              decoration: BoxDecoration(
+                color: colorScheme.surfaceVariant,
+                borderRadius: BorderRadius.circular(24),
+              ),
+              child: TextField(
+                controller: _messageController,
+                style: TextStyle(color: colorScheme.onSurface),
+                decoration: InputDecoration(
+                  hintText: 'Type your message...',
+                  hintStyle: TextStyle(color: colorScheme.onSurfaceVariant),
+                  border: InputBorder.none,
+                ),
+                onSubmitted: (_) => _sendMessage(),
+              ),
+            ),
+          ),
+          const SizedBox(width: 8),
           Container(
-            padding: const EdgeInsets.symmetric(vertical: 16, horizontal: 20),
             decoration: BoxDecoration(
-              color: colorScheme.surface,
+              color: Colors.green,
+              shape: BoxShape.circle,
               boxShadow: [
                 BoxShadow(
-                  color: colorScheme.shadow.withOpacity(0.2),
+                  color: Colors.green.withOpacity(0.3),
+                  blurRadius: 8,
                   offset: const Offset(0, 2),
-                  blurRadius: 4,
                 ),
               ],
             ),
-            child: SafeArea(
-              bottom: false,
-              child: Row(
-                children: [
-                  Container(
-                    width: 40,
-                    height: 40,
-                    decoration: BoxDecoration(
-                      color: Colors.green.withOpacity(0.2),
-                      shape: BoxShape.circle,
-                    ),
-                    child: const Icon(Icons.smart_toy, color: Colors.green),
-                  ),
-                  const SizedBox(width: 12),
-                  Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Text(
-                        'Chat with Ell-ena',
-                        style: TextStyle(
-                          color: colorScheme.onSurface,
-                          fontSize: 18,
-                          fontWeight: FontWeight.bold,
-                        ),
-                      ),
-                      Text(
-                        'Your AI Assistant',
-                        style: TextStyle(
-                            color: colorScheme.onSurfaceVariant, fontSize: 14),
-                      ),
-                    ],
-                  ),
-                  const Spacer(),
-                  Container(
-                    padding: const EdgeInsets.all(8),
-                    decoration: BoxDecoration(
-                      color: Colors.green.withOpacity(0.1),
-                      shape: BoxShape.circle,
-                    ),
-                    child: const Icon(
-                      Icons.info_outline,
-                      color: Colors.green,
-                      size: 20,
-                    ),
-                  ),
-                ],
-              ),
+            child: IconButton(
+              onPressed: _toggleListening,
+              icon: Icon(_isListening ? Icons.stop : Icons.mic),
+              color: Colors.white,
             ),
           ),
-          Expanded(
-            child: _messages.isEmpty
-                ? Center(
-                    child: Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        Icon(
-                          Icons.chat_bubble_outline,
-                          size: 64,
-                          color: colorScheme.onSurfaceVariant,
-                        ),
-                        const SizedBox(height: 16),
-                        Text(
-                          'Start a conversation with Ell-ena',
-                          style: TextStyle(
-                            color: colorScheme.onSurfaceVariant,
-                            fontSize: 16,
-                          ),
-                        ),
-                      ],
-                    ),
-                  )
-                : ListView.builder(
-                    controller: _scrollController,
-                    padding: const EdgeInsets.all(16),
-                    itemCount: _messages.length + (_isProcessing ? 1 : 0),
-                    itemBuilder: (context, index) {
-                      if (_isProcessing && index == _messages.length) {
-                        // Show typing indicator
-                        return Align(
-                          alignment: Alignment.centerLeft,
-                          child: Container(
-                            margin: const EdgeInsets.symmetric(vertical: 8),
-                            padding: const EdgeInsets.symmetric(
-                                horizontal: 16, vertical: 12),
-                            decoration: BoxDecoration(
-                              color: colorScheme.surfaceVariant,
-                              borderRadius: BorderRadius.circular(20),
-                            ),
-                            child: LoadingAnimationWidget.staggeredDotsWave(
-                              color: Colors.green,
-                              size: 24,
-                            ),
-                          ),
-                        );
-                      }
-
-                      final message = _messages[index];
-                      if (message.isCard == true) {
-                        return _ItemCard(
-                          message: message,
-                          onViewItem: () => _navigateToItem(message),
-                        );
-                      }
-                      return _ChatBubble(message: message);
-                    },
-                  ),
-          ),
+          const SizedBox(width: 8),
           Container(
-            padding: const EdgeInsets.all(16),
             decoration: BoxDecoration(
-              color: colorScheme.surface,
-              borderRadius: const BorderRadius.only(
-                topLeft: Radius.circular(20),
-                topRight: Radius.circular(20),
-              ),
-            ),
-            child: Row(
-              children: [
-                Expanded(
-                  child: Container(
-                    padding: const EdgeInsets.symmetric(horizontal: 16),
-                    decoration: BoxDecoration(
-                      color: colorScheme.surfaceVariant,
-                      borderRadius: BorderRadius.circular(24),
-                    ),
-                    child: TextField(
-                      controller: _messageController,
-                      style: TextStyle(color: colorScheme.onSurface),
-                      decoration: InputDecoration(
-                        hintText: 'Type your message...',
-                        hintStyle:
-                            TextStyle(color: colorScheme.onSurfaceVariant),
-                        border: InputBorder.none,
-                      ),
-                      onSubmitted: (_) => _sendMessage(),
-                    ),
-                  ),
-                ),
-                const SizedBox(width: 8),
-                Container(
-                  decoration: BoxDecoration(
-                    color: Colors.green,
-                    shape: BoxShape.circle,
-                    boxShadow: [
-                      BoxShadow(
-                        color: Colors.green.withOpacity(0.3),
-                        blurRadius: 8,
-                        offset: const Offset(0, 2),
-                      ),
-                    ],
-                  ),
-                  child: IconButton(
-                    onPressed: _toggleListening,
-                    icon: Icon(_isListening ? Icons.stop : Icons.mic),
-                    color: Colors.white,
-                  ),
-                ),
-                const SizedBox(width: 8),
-                Container(
-                  decoration: BoxDecoration(
-                    color: Colors.green,
-                    shape: BoxShape.circle,
-                    boxShadow: [
-                      BoxShadow(
-                        color: Colors.green.withOpacity(0.3),
-                        blurRadius: 8,
-                        offset: const Offset(0, 2),
-                      ),
-                    ],
-                  ),
-                  child: IconButton(
-                    onPressed: _isProcessing ? null : _sendMessage,
-                    icon: const Icon(Icons.send),
-                    color: Colors.white,
-                  ),
+              color: Colors.green,
+              shape: BoxShape.circle,
+              boxShadow: [
+                BoxShadow(
+                  color: Colors.green.withOpacity(0.3),
+                  blurRadius: 8,
+                  offset: const Offset(0, 2),
                 ),
               ],
+            ),
+            child: IconButton(
+              onPressed: _isProcessing ? null : _sendMessage,
+              icon: const Icon(Icons.send),
+              color: Colors.white,
             ),
           ),
         ],
       ),
     );
   }
+
+  void _navigateToItem(ChatMessage message) {
+    try {
+      if (message.cardType == 'task' && message.cardData?['task'] != null) {
+        Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (_) =>
+                TaskDetailScreen(taskId: message.cardData!['task']['id']),
+          ),
+        );
+      } else if (message.cardType == 'ticket' &&
+          message.cardData?['ticket'] != null) {
+        Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (_) => TicketDetailScreen(
+                ticketId: message.cardData!['ticket']['id']),
+          ),
+        );
+      } else if (message.cardType == 'meeting' &&
+          message.cardData?['meeting'] != null) {
+        Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (_) => MeetingDetailScreen(
+                meetingId: message.cardData!['meeting']['id']),
+          ),
+        );
+      } else {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Could not navigate to the item. Details missing.'),
+            backgroundColor: Colors.red,
+          ),
+        );
+      }
+    } catch (e) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+            content: Text('Navigation error: $e'),
+            backgroundColor: Colors.red),
+      );
+    }
+  }
 }
 
 class _ChatBubble extends StatelessWidget {
   final ChatMessage message;
-
   const _ChatBubble({required this.message});
 
   @override
@@ -1388,6 +1071,7 @@ class _ChatBubble extends StatelessWidget {
         message.isUser ? Colors.white : colorScheme.onSurface;
     final bubbleColor =
         message.isUser ? Colors.green : colorScheme.surfaceVariant;
+
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 8),
       child: Row(
@@ -1399,13 +1083,13 @@ class _ChatBubble extends StatelessWidget {
           const SizedBox(width: 8),
           Flexible(
             child: Container(
-              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+              padding:
+                  const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
               decoration: BoxDecoration(
                 color: bubbleColor,
                 borderRadius: BorderRadius.circular(20),
               ),
-              child:
-                  _buildFormattedText(context, message.text, bubbleTextColor),
+              child: _buildFormattedText(context, message.text, bubbleTextColor),
             ),
           ),
           const SizedBox(width: 8),
@@ -1415,137 +1099,86 @@ class _ChatBubble extends StatelessWidget {
     );
   }
 
-  // Build formatted text that handles markdown-like formatting
   Widget _buildFormattedText(
       BuildContext context, String text, Color textColor) {
-    // Check if text contains formatting indicators
     final containsFormatting = text.contains('*') ||
         text.contains('•') ||
         text.contains('📅') ||
         text.contains('🕒');
 
     if (!containsFormatting) {
-      // Simple text without formatting
       return Text(text, style: TextStyle(color: textColor));
     }
 
-    // Split the text by lines to handle each line separately
     final lines = text.split('\n');
     final widgets = <Widget>[];
 
-    for (int i = 0; i < lines.length; i++) {
-      final line = lines[i];
-
-      // Handle empty lines
+    for (final line in lines) {
       if (line.isEmpty) {
         widgets.add(const SizedBox(height: 8));
         continue;
       }
 
-      // Handle headers (lines with asterisks)
       if (line.startsWith('*') && line.endsWith('*')) {
         final content = line.substring(1, line.length - 1).trim();
-        widgets.add(
-          Padding(
-            padding: const EdgeInsets.only(bottom: 4),
-            child: Text(
-              content,
+        widgets.add(Padding(
+          padding: const EdgeInsets.only(bottom: 4),
+          child: Text(content,
               style: TextStyle(
-                color: textColor,
-                fontWeight: FontWeight.bold,
-                fontSize: 16,
+                  color: textColor,
+                  fontWeight: FontWeight.bold,
+                  fontSize: 16)),
+        ));
+      } else if (line.startsWith('•')) {
+        widgets.add(Padding(
+          padding: const EdgeInsets.only(bottom: 4, left: 8),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text('•',
+                  style: TextStyle(
+                      color: textColor, fontWeight: FontWeight.bold)),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(line.substring(1).trim(),
+                    style: TextStyle(color: textColor)),
               ),
-            ),
+            ],
           ),
-        );
-      }
-      // Handle bullet points
-      else if (line.startsWith('•')) {
-        widgets.add(
-          Padding(
-            padding: const EdgeInsets.only(bottom: 4, left: 8),
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Text('•',
-                    style: TextStyle(
-                        color: textColor, fontWeight: FontWeight.bold)),
-                const SizedBox(width: 8),
-                Expanded(
-                  child: Text(
-                    line.substring(1).trim(),
-                    style: TextStyle(color: textColor),
-                  ),
-                ),
-              ],
-            ),
-          ),
-        );
-      }
-      // Handle emoji indicators (like meeting date/time)
-      else if (line.startsWith('📅') || line.startsWith('🕒')) {
-        widgets.add(
-          Padding(
-            padding: const EdgeInsets.only(bottom: 4),
-            child: Text(
-              line,
+        ));
+      } else if (line.startsWith('📅') || line.startsWith('🕒')) {
+        widgets.add(Padding(
+          padding: const EdgeInsets.only(bottom: 4),
+          child: Text(line,
               style: TextStyle(
                 color: textColor,
-                fontWeight:
-                    line.startsWith('📅') ? FontWeight.bold : FontWeight.normal,
+                fontWeight: line.startsWith('📅')
+                    ? FontWeight.bold
+                    : FontWeight.normal,
                 fontSize: line.startsWith('📅') ? 16 : 14,
-              ),
-            ),
-          ),
-        );
-      }
-      // Handle section headers (lines with asterisks like *Key Points:*)
-      else if (line.contains('*')) {
-        // Replace asterisks with empty string and make bold
-        final content = line.replaceAll('*', '');
-        widgets.add(
-          Padding(
-            padding: const EdgeInsets.only(top: 8, bottom: 4),
-            child: Text(
-              content,
+              )),
+        ));
+      } else if (line.contains('*')) {
+        widgets.add(Padding(
+          padding: const EdgeInsets.only(top: 8, bottom: 4),
+          child: Text(line.replaceAll('*', ''),
               style: TextStyle(
-                color: textColor,
-                fontWeight: FontWeight.bold,
-              ),
-            ),
-          ),
-        );
-      }
-      // Handle separator lines
-      else if (line.startsWith('---')) {
-        widgets.add(
-          Padding(
-            padding: const EdgeInsets.symmetric(vertical: 8),
-            child: Container(
-              height: 1,
-              color: Theme.of(context).dividerColor,
-            ),
-          ),
-        );
-      }
-      // Regular text
-      else {
-        widgets.add(
-          Padding(
-            padding: const EdgeInsets.only(bottom: 4),
-            child: Text(
-              line,
-              style: TextStyle(color: textColor),
-            ),
-          ),
-        );
+                  color: textColor, fontWeight: FontWeight.bold)),
+        ));
+      } else if (line.startsWith('---')) {
+        widgets.add(Padding(
+          padding: const EdgeInsets.symmetric(vertical: 8),
+          child: Container(height: 1, color: Theme.of(context).dividerColor),
+        ));
+      } else {
+        widgets.add(Padding(
+          padding: const EdgeInsets.only(bottom: 4),
+          child: Text(line, style: TextStyle(color: textColor)),
+        ));
       }
     }
 
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: widgets,
-    );
+    return Column(crossAxisAlignment: CrossAxisAlignment.start, children: widgets);
   }
 
   Widget _buildAvatar(BuildContext context, {required bool isUser}) {
@@ -1580,7 +1213,6 @@ class _ItemCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // Set icon and title based on card type
     IconData icon;
     String title;
 
@@ -1626,28 +1258,21 @@ class _ItemCard extends StatelessWidget {
               children: [
                 Icon(icon, color: Colors.green, size: 20),
                 const SizedBox(width: 8),
-                Text(
-                  title,
-                  style: const TextStyle(
-                    color: Colors.green,
-                    fontWeight: FontWeight.bold,
-                  ),
-                ),
+                Text(title,
+                    style: const TextStyle(
+                        color: Colors.green, fontWeight: FontWeight.bold)),
                 const Spacer(),
-                if (message.cardType == 'task' || message.cardType == 'ticket')
-                  Text(
-                    'Created just now',
-                    style: TextStyle(
-                        color: colorScheme.onSurfaceVariant, fontSize: 12),
-                  ),
                 if (message.cardType == 'meeting' &&
-                    message.cardData != null &&
-                    message.cardData!['meeting'] != null)
+                    message.cardData?['meeting'] != null)
                   Text(
                     _formatDate(message.cardData!['meeting']['meeting_date']),
                     style: TextStyle(
                         color: colorScheme.onSurfaceVariant, fontSize: 12),
-                  ),
+                  )
+                else
+                  Text('Created just now',
+                      style: TextStyle(
+                          color: colorScheme.onSurfaceVariant, fontSize: 12)),
               ],
             ),
           ),
@@ -1656,42 +1281,34 @@ class _ItemCard extends StatelessWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Text(
-                  message.text,
-                  style: TextStyle(color: colorScheme.onSurface, fontSize: 16),
-                ),
+                Text(message.text,
+                    style:
+                        TextStyle(color: colorScheme.onSurface, fontSize: 16)),
                 const SizedBox(height: 16),
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.end,
-                  children: [
-                    TextButton(
-                      onPressed: onViewItem,
-                      style: TextButton.styleFrom(
-                        backgroundColor: Colors.green.withOpacity(0.1),
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(20),
-                        ),
-                      ),
-                      child: Row(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          Text(
-                            'View ${message.cardType?.capitalize() ?? 'Item'}',
-                            style: const TextStyle(
-                              color: Colors.green,
-                              fontWeight: FontWeight.bold,
-                            ),
-                          ),
-                          const SizedBox(width: 4),
-                          const Icon(
-                            Icons.arrow_forward,
-                            color: Colors.green,
-                            size: 16,
-                          ),
-                        ],
-                      ),
+                Align(
+                  alignment: Alignment.centerRight,
+                  child: TextButton(
+                    onPressed: onViewItem,
+                    style: TextButton.styleFrom(
+                      backgroundColor: Colors.green.withOpacity(0.1),
+                      shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(20)),
                     ),
-                  ],
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(
+                          'View ${message.cardType?.capitalize() ?? 'Item'}',
+                          style: const TextStyle(
+                              color: Colors.green,
+                              fontWeight: FontWeight.bold),
+                        ),
+                        const SizedBox(width: 4),
+                        const Icon(Icons.arrow_forward,
+                            color: Colors.green, size: 16),
+                      ],
+                    ),
+                  ),
                 ),
               ],
             ),
@@ -1703,11 +1320,10 @@ class _ItemCard extends StatelessWidget {
 
   String _formatDate(String? dateString) {
     if (dateString == null) return '';
-
     try {
       final date = DateTime.parse(dateString);
       return DateFormat('MMM d, yyyy • h:mm a').format(date);
-    } catch (e) {
+    } catch (_) {
       return '';
     }
   }
@@ -1720,7 +1336,7 @@ class ChatMessage {
   final bool isCard;
   final String? cardType;
   final Map<String, dynamic>? cardData;
-  final String? avatarUrl; // Add avatar URL for profile pictures
+  final String? avatarUrl;
 
   ChatMessage({
     required this.text,
@@ -1733,9 +1349,9 @@ class ChatMessage {
   });
 }
 
-// Extension to capitalize first letter of a string
 extension StringExtension on String {
   String capitalize() {
+    if (isEmpty) return this;
     return "${this[0].toUpperCase()}${substring(1)}";
   }
 }

--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -1,7 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
-import '../../widgets/custom_widgets.dart';
-import '../../services/navigation_service.dart';
 import '../workspace/workspace_screen.dart';
 import '../calendar/calendar_screen.dart';
 import '../profile/profile_screen.dart';
@@ -17,122 +14,50 @@ class HomeScreen extends StatefulWidget {
   State<HomeScreen> createState() => _HomeScreenState();
 }
 
-class _HomeScreenState extends State<HomeScreen>
-    with SingleTickerProviderStateMixin {
-  final TextEditingController _messageController = TextEditingController();
-  final ScrollController _scrollController = ScrollController();
-  final List<ChatMessage> _messages = [];
-  bool _isListening = false;
-  int _selectedIndex = 0;
-  bool _isFabExpanded = false;
-  late AnimationController _fabController;
-  late Animation<double> _fabAnimation;
+class _HomeScreenState extends State<HomeScreen> {
+  static const int _chatTabIndex = 3;
+  static const int _tabCount = 5;
 
-  List<Widget> _screens = [];
+  int _selectedIndex = 0;
+  bool _chatInitialized = false;
+  Map<String, dynamic>? _chatArgs;
 
   @override
   void initState() {
     super.initState();
-    _fabController = AnimationController(
-      duration: const Duration(milliseconds: 300),
-      vsync: this,
-    );
-    _fabAnimation = CurvedAnimation(
-      parent: _fabController,
-      curve: Curves.easeOut,
-      reverseCurve: Curves.easeIn,
-    );
 
-    // Initialize screens
-    _initializeScreens();
+    // Parse arguments synchronously before first build so ChatScreen
+    // receives _chatArgs on its very first render with no race condition.
+    final args = widget.arguments;
+    if (args != null) {
+      final int targetIndex =
+          (args['screen'] is int) ? args['screen'] as int : _selectedIndex;
 
-    // Handle initial arguments if provided
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (widget.arguments != null) {
-        if (widget.arguments!.containsKey('screen') &&
-            widget.arguments!['screen'] is int) {
-          setState(() {
-            _selectedIndex = widget.arguments!['screen'];
-          });
-        }
+      _selectedIndex = (targetIndex >= 0 && targetIndex < _tabCount)
+          ? targetIndex
+          : _selectedIndex;
 
-        // Handle initial message for chat screen
-        if (widget.arguments!.containsKey('initial_message') &&
-            widget.arguments!['initial_message'] is String &&
-            _selectedIndex == 3) {
-          // Update the chat screen with the initial message
-          setState(() {
-            _screens[3] = ChatScreen(arguments: {
-              'initial_message': widget.arguments!['initial_message']
-            });
-          });
-        }
+      // Always capture initial_message regardless of which tab is targeted,
+      // so the message is available when the user navigates to the chat tab.
+      final dynamic initialMessage = args['initial_message'];
+      if (initialMessage is String && initialMessage.trim().isNotEmpty) {
+        _chatArgs = {'initial_message': initialMessage.trim()};
       }
-    });
+    }
+
+    // If starting on chat tab, initialize it immediately.
+    if (_selectedIndex == _chatTabIndex) {
+      _chatInitialized = true;
+    }
   }
 
-  void _initializeScreens() {
-    _screens = [
-      const DashboardScreen(),
-      const CalendarScreen(),
-      const WorkspaceScreen(),
-      const ChatScreen(),
-      const ProfileScreen(),
-    ];
-  }
-
-  @override
-  void dispose() {
-    _messageController.dispose();
-    _scrollController.dispose();
-    _fabController.dispose();
-    super.dispose();
-  }
-
-  void _sendMessage() {
-    if (_messageController.text.trim().isEmpty) return;
-
+  void _onTap(int index) {
     setState(() {
-      _messages.add(
-        ChatMessage(
-          text: _messageController.text,
-          isUser: true,
-          timestamp: DateTime.now(),
-        ),
-      );
-      _messageController.clear();
-    });
-
-    _scrollToBottom();
-    // TODO: Implement AI response
-  }
-
-  void _scrollToBottom() {
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (_scrollController.hasClients) {
-        _scrollController.animateTo(
-          _scrollController.position.maxScrollExtent,
-          duration: const Duration(milliseconds: 300),
-          curve: Curves.easeOut,
-        );
-      }
-    });
-  }
-
-  void _toggleListening() {
-    setState(() {
-      _isListening = !_isListening;
-    });
-    // TODO: Implement voice recognition
-  }
-
-  void _toggleFab() {
-    setState(() {
-      _isFabExpanded = !_isFabExpanded;
-      if (_isFabExpanded) {
-        _fabController.forward();
-      } else {
-        _fabController.reverse();
+      _selectedIndex = index;
+      // Lazy-load ChatScreen only when user first visits the chat tab.
+      // This avoids unnecessary startup cost from eager IndexedStack init.
+      if (index == _chatTabIndex) {
+        _chatInitialized = true;
       }
     });
   }
@@ -140,11 +65,31 @@ class _HomeScreenState extends State<HomeScreen>
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+
+    final screens = <Widget>[
+      const DashboardScreen(),
+      const CalendarScreen(),
+      const WorkspaceScreen(),
+
+      // Lazy-load ChatScreen: only initialize when user first visits chat tab.
+      _chatInitialized
+          ? ChatScreen(
+              key: const PageStorageKey('chat_screen'),
+              arguments: _chatArgs,
+            )
+          : const SizedBox.shrink(),
+
+      const ProfileScreen(),
+    ];
+
     return Scaffold(
-      body: IndexedStack(index: _selectedIndex, children: _screens),
+      body: IndexedStack(
+        index: _selectedIndex,
+        children: screens,
+      ),
       bottomNavigationBar: BottomNavigationBar(
         currentIndex: _selectedIndex,
-        onTap: (index) => setState(() => _selectedIndex = index),
+        onTap: _onTap,
         type: BottomNavigationBarType.fixed,
         selectedItemColor: theme.colorScheme.primary,
         unselectedItemColor: theme.colorScheme.onSurfaceVariant,
@@ -157,57 +102,20 @@ class _HomeScreenState extends State<HomeScreen>
             icon: Icon(Icons.calendar_today),
             label: 'Calendar',
           ),
-          BottomNavigationBarItem(icon: Icon(Icons.work), label: 'Workspace'),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.work),
+            label: 'Workspace',
+          ),
           BottomNavigationBarItem(
             icon: Icon(Icons.chat_bubble_outline),
             label: 'Chat',
           ),
-          BottomNavigationBarItem(icon: Icon(Icons.person), label: 'Profile'),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.person),
+            label: 'Profile',
+          ),
         ],
       ),
     );
   }
-}
-
-class _ChatBubble extends StatelessWidget {
-  final ChatMessage message;
-
-  const _ChatBubble({required this.message});
-
-  @override
-  Widget build(BuildContext context) {
-    return Align(
-      alignment: message.isUser ? Alignment.centerRight : Alignment.centerLeft,
-      child: Container(
-        margin: const EdgeInsets.symmetric(vertical: 4),
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
-        decoration: BoxDecoration(
-          color: message.isUser
-              ? Colors.green.shade400
-              : Theme.of(context).colorScheme.surfaceContainerHighest,
-          borderRadius: BorderRadius.circular(20),
-        ),
-        child: Text(
-          message.text,
-          style: TextStyle(
-            color: message.isUser
-                ? Colors.white
-                : Theme.of(context).colorScheme.onSurface,
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-class ChatMessage {
-  final String text;
-  final bool isUser;
-  final DateTime timestamp;
-
-  ChatMessage({
-    required this.text,
-    required this.isUser,
-    required this.timestamp,
-  });
 }


### PR DESCRIPTION
closes #122 
## What changed

This PR refactors chat architecture so that all chat-related state and logic
is owned by `ChatScreen` instead of `HomeScreen`.

## Why

Previously, `HomeScreen` managed chat controllers and logic while not rendering
the chat UI. This violated feature ownership and made the code harder to
maintain and extend.

## Key improvements

- Chat state now lives entirely inside `ChatScreen`
- HomeScreen is responsible only for navigation
- Initial chat messages are passed via arguments
- Prevents duplicated or lost messages on rebuild

## Impact

- Clear separation of concerns
- Easier to test and scale chat features
- Aligns with Flutter architectural best practices


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * User avatars in chat messages
  * Card-based messages with "View" to open item details
  * Typing indicator for in-progress AI responses

* **Improvements**
  * More reliable speech-to-text with a stable listening dialog and better error handling
  * Startup/service readiness gating with message queuing and automatic flush
  * Stronger safeguards to prevent UI updates after screen disposal
  * Home screen now forwards initial chat content and centralizes chat state
* **UI**
  * Chat layout reorganized into clearer header, list, and input sections
<!-- end of auto-generated comment: release notes by coderabbit.ai -->