### PR TITLE
Add similarity search functions for tasks and tickets

### DIFF
--- a/supabase/migrations/20251021110000_task_ticket_vector_search.sql
+++ b/supabase/migrations/20251021110000_task_ticket_vector_search.sql
@@ -1,0 +1,48 @@
+CREATE OR REPLACE FUNCTION get_similar_tasks(
+    query_embedding vector(768),
+    match_count INT DEFAULT 3
+)
+RETURNS TABLE (
+    task_id UUID,
+    title TEXT,
+    description TEXT,
+    similarity FLOAT
+) AS $$
+BEGIN
+    RETURN QUERY
+    SELECT
+        t.id AS task_id,
+        t.title,
+        t.description,
+        1 - (t.description_embedding <=> query_embedding) AS similarity
+    FROM tasks t
+    WHERE t.description_embedding IS NOT NULL
+    ORDER BY t.description_embedding <=> query_embedding
+    LIMIT match_count;
+END;
+$$ LANGUAGE plpgsql;
+
+
+CREATE OR REPLACE FUNCTION get_similar_tickets(
+    query_embedding vector(768),
+    match_count INT DEFAULT 3
+)
+RETURNS TABLE (
+    ticket_id UUID,
+    title TEXT,
+    description TEXT,
+    similarity FLOAT
+) AS $$
+BEGIN
+    RETURN QUERY
+    SELECT
+        tk.id AS ticket_id,
+        tk.title,
+        tk.description,
+        1 - (tk.description_embedding <=> query_embedding) AS similarity
+    FROM tickets tk
+    WHERE tk.description_embedding IS NOT NULL
+    ORDER BY tk.description_embedding <=> query_embedding
+    LIMIT match_count;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
This PR introduces SQL helper functions to enable vector similarity search for tasks and tickets using the pgvector setup added in PR1.

It is a follow-up, incremental step toward Issue #65. While PR1 introduced the description_embedding vector(768) columns for tasks and tickets (storage layer), this PR builds on that foundation by adding database-level similarity search functions (retrieval layer).
No embedding generation, indexing, or AI service integration is included here. This PR strictly enables semantic retrieval capability at the database level.

 Dependency Note:
This PR depends on PR1, as it relies on the description_embedding columns introduced there. PR1 must be merged before this PR to ensure the functions execute against an existing schema. pr1 : #160 

 Changes Made

Added get_similar_tasks(query_embedding, match_count) SQL function
Added get_similar_tickets(query_embedding, match_count) SQL function

Each function:
Computes cosine similarity using <=>
Returns top-k most semantically similar rows
Ignores rows without embeddings (IS NOT NULL)
Added new Supabase migration file to maintain proper migration ordering

✅ Checklist

 I have read the contributing guidelines.

 I have added tests that prove my fix is effective or that my feature works.
(Not applicable – database-level capability addition only.)

 I have added necessary documentation (if applicable).
(Not required at this stage.)

 Any dependent changes have been merged and published in downstream modules.
(Depends on PR1 – embedding schema changes.)