### PR TITLE
docs: clarify schema source of truth and SQL structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,9 @@ lib/
 
 ### SQL Structure
 
+The following SQL scripts represent structured database definitions used during development. Supabase deployments rely on migration files located in `supabase/migrations/`.
+
+
 ```
 sqls/
 ├── 01_user_auth_schema.sql    # User authentication schema
@@ -212,6 +215,13 @@ sqls/
 ├── 09_meeting_vector_search.sql # Vector search capabilities
 └── 10_generate_missing_embeddings.sql # Embedding generation
 ```
+
+### Database Schema Source of Truth
+
+Ell-ena maintains database migrations under `supabase/migrations/`, which serves as the authoritative schema source for Supabase deployments.
+
+The `sqls/` directory contains structured SQL scripts used during development and feature implementation. When modifying database structure, contributors should ensure consistency with the migration files inside `supabase/migrations/`.
+
 
 ### Future Enhancements
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #168

## 📝 Description

This pull request improves documentation clarity around the database schema structure by explicitly defining the relationship between the `sqls/` directory and `supabase/migrations/`. At present, both locations contain SQL definitions, which may lead contributors to uncertainty about the authoritative source of truth for schema changes. This update documents that Supabase deployments rely on migration files under `supabase/migrations/`, while the `sqls/` directory contains structured SQL scripts used during development and feature implementation. By formalizing this distinction in the README, the project becomes easier to understand for new contributors and reduces the risk of inconsistent schema updates as Ell-ena continues to evolve.

## 🔧 Changes Made

- Added clarification under the **SQL Structure** section in `README.md`
- Introduced a **Database Schema Source of Truth** section
- Documented the intended role of `supabase/migrations/` for deployments
- Clarified the purpose of the `sqls/` directory for development usage

### ✅ Checklist

- [x] I have read the contributing guidelines.
- [x] I have added necessary documentation (if applicable).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified SQL structure and organization of database scripts and migrations
  * Documented database schema as the authoritative source of truth
  * Added contributor guidance for maintaining consistency between database files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->