### PR TITLE
Add defensive JSON parsing in generateChatResponse to prevent runtime…

### DIFF
--- a/lib/services/ai_service.dart
+++ b/lib/services/ai_service.dart
@@ -681,16 +681,20 @@ Future<List<Map<String, dynamic>>> getRelevantMeetingSummaries(String query) asy
   // Helper method to detect if a query is meeting-related
   bool _isMeetingRelatedQuery(String query) {
     final meetingKeywords = [
-      'meeting', 'meetings', 'meet',
-      'call', 'last call', 'previous call',
-      'discussion', 'last discussion', 'previous discussion',
-      'talked about', 'last talked about', 'previous talked about',
-      'said in', 'mentioned in', 'last mentioned in', 'previous mentioned in',
-      'spoke about', 'last spoke about', 'previous spoke about',
-      'last discussed', 'previous discussed',
-      'summary', 'minutes', 'transcript', 'recording',
+      'meeting', 'meetings', 'call', 'discussion', 'talked about',
+      'said in', 'mentioned in', 'last meeting', 'previous meeting',
+      'summary', 'minutes', 'transcript', 'recording', 'spoke about', 'last meet', 'previous meeting',
+      'last call', 'previous call', 'last discussion', 'previous discussion', 'last talked about', 'previous talked about',
+      'last mentioned in', 'previous mentioned in', 'last spoke about', 'previous spoke about', 'last discussed', 'previous discussed',
+      'meeting', 'meet', 'call', 'discussion', 'talked about',
+      'said in', 'mentioned in', 'last meeting', 'previous meeting',
+      'summary', 'minutes', 'transcript', 'recording', 'spoke about', 'last meet', 'previous meeting',
+      'last call', 'previous call', 'last discussion', 'previous discussion', 'last talked about', 'previous talked about',
+      'last mentioned in', 'previous mentioned in', 'last spoke about', 'previous spoke about', 'last discussed', 'previous discussed',
+      'meeting', 'meet', 'call', 'discussion', 'talked about',
+      'said in', 'mentioned in', 'last meeting', 'previous meeting',
+      'summary', 'minutes', 'transcript', 'recording', 'spoke about', 'last meet', 'previous meeting',
     ];
-
     final queryLower = query.toLowerCase();
     return meetingKeywords.any((keyword) => queryLower.contains(keyword));
   }


### PR DESCRIPTION
Closes #170

📝 Description

This PR adds defensive validation when parsing the Gemini API response inside generateChatResponse().

The previous implementation assumed that the response always contained a non-empty candidates list and directly accessed nested fields using casting and deep indexing. Since the response comes from an external API, its structure cannot be guaranteed and could potentially cause runtime errors if fields are missing or malformed.

This update ensures the response structure is validated before accessing nested values, preventing potential crashes while preserving existing behavior.

🔧 Changes Made

Added validation to ensure candidates is a non-empty List.
Added checks to confirm content exists and is a Map.
Added checks to confirm parts is a non-empty List.
Safely detect functionCall using type checks.
Safely extract text using guarded lookup instead of deep indexing.

No changes were made to the overall response format or functionality.

✅ Checklist

 I have read the contributing guidelines.
 I have added tests that prove my fix is effective or that my feature works.
 I have added necessary documentation (if applicable).
 Any dependent changes have been merged and published in downstream modules.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stronger validation of AI API responses with explicit error messages for malformed or non-200 replies.
  * Function-call responses are now reliably detected and validated; invalid names produce clear error responses and malformed arguments default safely.
  * Safer text extraction fallback when no function-call is present, avoiding silent failures.
  * Consolidated meeting-query keywords to reduce duplication and false positives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->