### PR TITLE
Passing an argument of a different type will trigger an unhandled runtime exception and crash the app.

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -51,13 +51,19 @@ class MyApp extends StatelessWidget {
             settings: settings,
           );
         } else if (settings.name == '/home') {
-          final args = settings.arguments as Map<String, dynamic>?;
+          final args = (settings.arguments is Map<String, dynamic>) 
+              ? settings.arguments as Map<String, dynamic> 
+              : null;
+              
           return MaterialPageRoute(
             builder: (context) => HomeScreen(arguments: args),
             settings: settings,
           );
         } else if (settings.name == '/chat') {
-          final args = settings.arguments as Map<String, dynamic>?;
+          final args = (settings.arguments is Map<String, dynamic>) 
+              ? settings.arguments as Map<String, dynamic> 
+              : null;
+              
           return MaterialPageRoute(
             builder: (context) => ChatScreen(arguments: args),
             settings: settings,


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #177 


## 📝 Description
Check issue #177 



### ✅ Checklist

- [x] I have read the contributing guidelines.
- [x] I have added necessary documentation (if applicable).
- [x] Any dependent changes have been merged and published in downstream modules.

@SharkyBytes Please have a look

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced route argument validation for home and chat routes to prevent crashes from unexpected argument types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->