### PR TITLE
fix: resolve calendar crash and improve date/time logic

### DIFF
--- a/lib/screens/calendar/calendar_screen.dart
+++ b/lib/screens/calendar/calendar_screen.dart
@@ -284,8 +284,8 @@ class _CalendarScreenState extends State<CalendarScreen> {
         _events[dateOnly]!.add(CalendarEvent(
           title: ticket['title'] ?? 'Untitled Ticket',
           startTime: TimeOfDay(hour: createdAt.hour, minute: createdAt.minute),
-          endTime: TimeOfDay.fromDateTime(
-              createdAt.add(const Duration(hours: 1))),
+          endTime:
+              TimeOfDay.fromDateTime(createdAt.add(const Duration(hours: 1))),
           type: EventType.ticket,
           id: ticket['id'],
         ));
@@ -326,8 +326,8 @@ class _CalendarScreenState extends State<CalendarScreen> {
           title: meeting['title'] ?? 'Untitled Meeting',
           startTime:
               TimeOfDay(hour: meetingDate.hour, minute: meetingDate.minute),
-          endTime: TimeOfDay.fromDateTime(
-              meetingDate.add(const Duration(hours: 1))),
+          endTime:
+              TimeOfDay.fromDateTime(meetingDate.add(const Duration(hours: 1))),
           type: EventType.meeting,
           id: meeting['id'],
         ));

--- a/lib/screens/calendar/calendar_screen.dart
+++ b/lib/screens/calendar/calendar_screen.dart
@@ -371,7 +371,7 @@ class _CalendarScreenState extends State<CalendarScreen> {
         padding: const EdgeInsets.all(8.0),
         child: TableCalendar(
           firstDay: DateTime.utc(2024, 1, 1),
-          lastDay: DateTime.utc(2025, 12, 31),
+          lastDay: DateTime.utc(2030, 12, 31),
           focusedDay: _focusedDay,
           calendarFormat: _calendarFormat,
           selectedDayPredicate: (day) => isSameDay(_selectedDay, day),

--- a/lib/screens/calendar/calendar_screen.dart
+++ b/lib/screens/calendar/calendar_screen.dart
@@ -284,8 +284,8 @@ class _CalendarScreenState extends State<CalendarScreen> {
         _events[dateOnly]!.add(CalendarEvent(
           title: ticket['title'] ?? 'Untitled Ticket',
           startTime: TimeOfDay(hour: createdAt.hour, minute: createdAt.minute),
-          endTime:
-              TimeOfDay(hour: createdAt.hour + 1, minute: createdAt.minute),
+          endTime: TimeOfDay.fromDateTime(
+              createdAt.add(const Duration(hours: 1))),
           type: EventType.ticket,
           id: ticket['id'],
         ));
@@ -326,8 +326,8 @@ class _CalendarScreenState extends State<CalendarScreen> {
           title: meeting['title'] ?? 'Untitled Meeting',
           startTime:
               TimeOfDay(hour: meetingDate.hour, minute: meetingDate.minute),
-          endTime:
-              TimeOfDay(hour: meetingDate.hour + 1, minute: meetingDate.minute),
+          endTime: TimeOfDay.fromDateTime(
+              meetingDate.add(const Duration(hours: 1))),
           type: EventType.meeting,
           id: meeting['id'],
         ));
@@ -371,7 +371,7 @@ class _CalendarScreenState extends State<CalendarScreen> {
         padding: const EdgeInsets.all(8.0),
         child: TableCalendar(
           firstDay: DateTime.utc(2024, 1, 1),
-          lastDay: DateTime.utc(2030, 12, 31),
+          lastDay: DateTime.utc(DateTime.now().year + 10, 12, 31),
           focusedDay: _focusedDay,
           calendarFormat: _calendarFormat,
           selectedDayPredicate: (day) => isSameDay(_selectedDay, day),
@@ -711,7 +711,8 @@ class _CalendarScreenState extends State<CalendarScreen> {
         result = await Navigator.push(
           context,
           MaterialPageRoute(
-            builder: (context) => const CreateMeetingScreen(),
+            builder: (context) =>
+                CreateMeetingScreen(initialDateTime: selectedDateTime),
           ),
         );
         break;
@@ -719,7 +720,8 @@ class _CalendarScreenState extends State<CalendarScreen> {
         result = await Navigator.push(
           context,
           MaterialPageRoute(
-            builder: (context) => const CreateTaskScreen(),
+            builder: (context) =>
+                CreateTaskScreen(initialDateTime: selectedDateTime),
           ),
         );
         break;
@@ -727,7 +729,8 @@ class _CalendarScreenState extends State<CalendarScreen> {
         result = await Navigator.push(
           context,
           MaterialPageRoute(
-            builder: (context) => const CreateTicketScreen(),
+            builder: (context) =>
+                CreateTicketScreen(initialDateTime: selectedDateTime),
           ),
         );
         break;

--- a/lib/screens/meetings/create_meeting_screen.dart
+++ b/lib/screens/meetings/create_meeting_screen.dart
@@ -22,6 +22,8 @@ class _CreateMeetingScreenState extends State<CreateMeetingScreen> {
 
   DateTime? _selectedDate;
   TimeOfDay? _selectedTime;
+  bool _isLoading = false;
+  bool _isGoogleMeetUrl = true;
 
   @override
   void initState() {
@@ -36,13 +38,8 @@ class _CreateMeetingScreenState extends State<CreateMeetingScreen> {
         hour: widget.initialDateTime!.hour,
         minute: widget.initialDateTime!.minute,
       );
-    } else {
-      _selectedDate = null;
-      _selectedTime = null;
     }
   }
-  bool _isLoading = false;
-  bool _isGoogleMeetUrl = true;
 
   @override
   void dispose() {
@@ -172,7 +169,7 @@ class _CreateMeetingScreenState extends State<CreateMeetingScreen> {
   Future<void> _selectDate() async {
     final picked = await showDatePicker(
       context: context,
-      initialDate: _selectedDate ?? DateTime.now(),
+      initialDate: (_selectedDate != null && !_selectedDate!.isBefore(DateTime.now())) ? _selectedDate! : DateTime.now(),
       firstDate: DateTime.now(),
       lastDate: DateTime.now().add(const Duration(days: 365)),
       builder: (context, child) => child!,

--- a/lib/screens/meetings/create_meeting_screen.dart
+++ b/lib/screens/meetings/create_meeting_screen.dart
@@ -3,7 +3,9 @@ import 'package:intl/intl.dart';
 import '../../services/supabase_service.dart';
 
 class CreateMeetingScreen extends StatefulWidget {
-  const CreateMeetingScreen({super.key});
+  const CreateMeetingScreen({super.key, this.initialDateTime});
+
+  final DateTime? initialDateTime;
 
   @override
   State<CreateMeetingScreen> createState() => _CreateMeetingScreenState();
@@ -20,6 +22,25 @@ class _CreateMeetingScreenState extends State<CreateMeetingScreen> {
 
   DateTime? _selectedDate;
   TimeOfDay? _selectedTime;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.initialDateTime != null) {
+      _selectedDate = DateTime(
+        widget.initialDateTime!.year,
+        widget.initialDateTime!.month,
+        widget.initialDateTime!.day,
+      );
+      _selectedTime = TimeOfDay(
+        hour: widget.initialDateTime!.hour,
+        minute: widget.initialDateTime!.minute,
+      );
+    } else {
+      _selectedDate = null;
+      _selectedTime = null;
+    }
+  }
   bool _isLoading = false;
   bool _isGoogleMeetUrl = true;
 

--- a/lib/screens/tasks/create_task_screen.dart
+++ b/lib/screens/tasks/create_task_screen.dart
@@ -75,12 +75,14 @@ class _CreateTaskScreenState extends State<CreateTaskScreen> {
   }
 
   Future<void> _selectDueDate() async {
+    final DateTime now = DateTime.now();
     final DateTime? picked = await showDatePicker(
       context: context,
-      initialDate:
-          _selectedDueDate ?? DateTime.now().add(const Duration(days: 1)),
-      firstDate: DateTime.now(),
-      lastDate: DateTime.now().add(const Duration(days: 365)),
+      initialDate: (_selectedDueDate != null && !_selectedDueDate!.isBefore(now))
+          ? _selectedDueDate!
+          : now.add(const Duration(days: 1)),
+      firstDate: now,
+      lastDate: now.add(const Duration(days: 365)),
       builder: (context, child) => child!,
     );
 

--- a/lib/screens/tasks/create_task_screen.dart
+++ b/lib/screens/tasks/create_task_screen.dart
@@ -75,14 +75,14 @@ class _CreateTaskScreenState extends State<CreateTaskScreen> {
   }
 
   Future<void> _selectDueDate() async {
-    final DateTime now = DateTime.now();
+    final DateTime today = DateUtils.dateOnly(DateTime.now());
     final DateTime? picked = await showDatePicker(
       context: context,
-      initialDate: (_selectedDueDate != null && !_selectedDueDate!.isBefore(now))
+      initialDate: (_selectedDueDate != null && !_selectedDueDate!.isBefore(today))
           ? _selectedDueDate!
-          : now.add(const Duration(days: 1)),
-      firstDate: now,
-      lastDate: now.add(const Duration(days: 365)),
+          : today,
+      firstDate: today,
+      lastDate: today.add(const Duration(days: 365)),
       builder: (context, child) => child!,
     );
 

--- a/lib/screens/tasks/create_task_screen.dart
+++ b/lib/screens/tasks/create_task_screen.dart
@@ -2,7 +2,9 @@ import 'package:flutter/material.dart';
 import '../../services/supabase_service.dart';
 
 class CreateTaskScreen extends StatefulWidget {
-  const CreateTaskScreen({super.key});
+  const CreateTaskScreen({super.key, this.initialDateTime});
+
+  final DateTime? initialDateTime;
 
   @override
   State<CreateTaskScreen> createState() => _CreateTaskScreenState();
@@ -21,6 +23,13 @@ class _CreateTaskScreenState extends State<CreateTaskScreen> {
   @override
   void initState() {
     super.initState();
+    if (widget.initialDateTime != null) {
+      _selectedDueDate = DateTime(
+        widget.initialDateTime!.year,
+        widget.initialDateTime!.month,
+        widget.initialDateTime!.day,
+      );
+    }
     _loadTeamMembers();
   }
 

--- a/lib/screens/tickets/create_ticket_screen.dart
+++ b/lib/screens/tickets/create_ticket_screen.dart
@@ -2,7 +2,9 @@ import 'package:flutter/material.dart';
 import '../../services/supabase_service.dart';
 
 class CreateTicketScreen extends StatefulWidget {
-  const CreateTicketScreen({super.key});
+  const CreateTicketScreen({super.key, this.initialDateTime});
+
+  final DateTime? initialDateTime;
 
   @override
   State<CreateTicketScreen> createState() => _CreateTicketScreenState();

--- a/lib/screens/tickets/create_ticket_screen.dart
+++ b/lib/screens/tickets/create_ticket_screen.dart
@@ -4,6 +4,7 @@ import '../../services/supabase_service.dart';
 class CreateTicketScreen extends StatefulWidget {
   const CreateTicketScreen({super.key, this.initialDateTime});
 
+  // Accepted for API consistency; tickets have no due-date field.
   final DateTime? initialDateTime;
 
   @override


### PR DESCRIPTION
Closes #110, Closes #181

## 📝 Description
This PR fixes a critical assertion crash on the Calendar tab. The table_calendar package was failing because the current date (2026) was beyond the hardcoded lastDay (2025). It also includes related calendar fixes, midnight rollover improvements, and UX enhancements.

## 🔧 Changes Made

### 🐛 Bug Fixes
* **Calendar date range crash**: Replaced the hardcoded lastDay with a dynamic value `DateTime.utc(DateTime.now().year + 10, 12, 31)` to prevent recurrence of assertion errors in future years.
* **23:00 time overflow**: Resolved an assertion failure for late-night events by using `TimeOfDay.fromDateTime` with a 1-hour `Duration` offset, ensuring correct midnight rollovers.
* **Date Picker Normalization**: Implemented `DateUtils.dateOnly` to ensure "Today" is correctly pre-filled in the date picker when selected from the calendar.

### ✨ New Features
* **Pre-filled create dialogs**: Enhanced the creation workflow by passing `initialDateTime` to Meeting and Task screens so selected dates/times are pre-filled.

## ✅ Verification
* **Hardware Tested**: Verified on a physical **Google Pixel 7** (Android).
* **Edge Cases**: Confirmed fix for 23:30 start times and past-date selection.

## 📷 Screenshots
| ![Fix](https://github.com/user-attachments/assets/d3845629-3632-42c7-a48c-9f38e6627c76) | 

## ✅ Checklist
- [x] I have read the contributing guidelines.
- [x] I have verified these fixes on a physical device.