### PR TITLE
update sdk constraint to support dart 3.11.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,8 +19,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.17.0 <=3.8.1"
-
+   sdk: '>=2.17.0 <4.0.0'
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions
 # consider running `flutter pub upgrade --major-versions`. Alternatively,


### PR DESCRIPTION
Updated sdk constraint in pubspec.yaml to support Dart 3.11.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Dart/Flutter SDK version requirements in project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->