### PR TITLE
fix(calendar): use dynamic meeting duration instead of hardcoded 60 minutes

### DIFF
--- a/lib/screens/calendar/calendar_screen.dart
+++ b/lib/screens/calendar/calendar_screen.dart
@@ -321,13 +321,15 @@ class _CalendarScreenState extends State<CalendarScreen> {
           _events[dateOnly] = [];
         }
 
-        // For meetings, assume 1 hour duration
+        // Get duration from meeting data, default to 60 minutes
+        final durationMinutes = meeting['duration_minutes'] as int? ?? 60;
+        final endDateTime = meetingDate.add(Duration(minutes: durationMinutes));
         _events[dateOnly]!.add(CalendarEvent(
           title: meeting['title'] ?? 'Untitled Meeting',
           startTime:
               TimeOfDay(hour: meetingDate.hour, minute: meetingDate.minute),
           endTime:
-              TimeOfDay(hour: meetingDate.hour + 1, minute: meetingDate.minute),
+              TimeOfDay(hour: endDateTime.hour, minute: endDateTime.minute),
           type: EventType.meeting,
           id: meeting['id'],
         ));


### PR DESCRIPTION
## Linked Issue
Fixes #139

## Problem
The `_processMeetingsData()` function in `calendar_screen.dart` was hardcoding meeting end time as `meetingDate.hour + 1`, completely ignoring the `duration_minutes` field stored in the database. This meant:

- A 75-minute meeting at 2:00 PM would display as **2:00 PM – 3:00 PM** instead of **2:00 PM – 3:15 PM**
- A 30-minute meeting at 2:00 PM would display as **2:00 PM – 3:00 PM** instead of **2:00 PM – 2:30 PM**
- Every single meeting, regardless of actual duration, always showed exactly 60 minutes

## Root Cause
```dart
// BEFORE (broken) — hardcoded +1 hour, ignores duration_minutes
endTime: TimeOfDay(hour: meetingDate.hour + 1, minute: meetingDate.minute),
```

## Fix
```dart
// AFTER — reads duration_minutes from data, defaults to 60 if missing
final durationMinutes = meeting['duration_minutes'] as int? ?? 60;
final endDateTime = meetingDate.add(Duration(minutes: durationMinutes));
endTime: TimeOfDay(hour: endDateTime.hour, minute: endDateTime.minute),
```

## Changes
| File | Change |
|------|--------|
| `lib/screens/calendar/calendar_screen.dart` | 2 lines replaced with 4 lines — reads `duration_minutes` and calculates correct `endTime` |

## Analysis Result
```
flutter analyze lib/screens/calendar/calendar_screen.dart
Analyzing calendar_screen.dart...
9 issues found (all pre-existing warnings unrelated to this fix)
✅ No new issues introduced
```

## Test Scenarios
| Duration | Before fix (wrong) | After fix (correct) |
|----------|-------------------|---------------------|
| 30 min meeting at 2:00 PM | 2:00 – 3:00 PM | 2:00 – 2:30 PM ✅ |
| 60 min meeting at 2:00 PM | 2:00 – 3:00 PM | 2:00 – 3:00 PM ✅ |
| 75 min meeting at 2:00 PM | 2:00 – 3:00 PM | 2:00 – 3:15 PM ✅ |
| 90 min meeting at 11:30 PM | 11:30 – 12:30 AM (wrong overflow) | 11:30 PM – 1:00 AM ✅ |

## Checklist
- [x] Fix is minimal and focused — only 1 file changed
- [x] Backwards compatible — defaults to 60 min if `duration_minutes` is null
- [x] No new lint warnings introduced
- [x] Existing functionality preserved