### PR TITLE
fix: guard BuildContext usage across async gaps in task, ticket, and workspace screens

### DIFF
--- a/lib/screens/tasks/task_screen.dart
+++ b/lib/screens/tasks/task_screen.dart
@@ -105,12 +105,14 @@ class _TaskScreenState extends State<TaskScreen> {
       _loadTasks();
     } catch (e) {
       debugPrint('Error updating task status: $e');
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text('Error updating task status: $e'),
-          backgroundColor: Colors.red,
-        ),
-      );
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Error updating task status: $e'),
+            backgroundColor: Colors.red,
+          ),
+        );
+      }
     }
   }
 
@@ -125,12 +127,14 @@ class _TaskScreenState extends State<TaskScreen> {
       _loadTasks();
     } catch (e) {
       debugPrint('Error updating task approval: $e');
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text('Error updating task approval: $e'),
-          backgroundColor: Colors.red,
-        ),
-      );
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Error updating task approval: $e'),
+            backgroundColor: Colors.red,
+          ),
+        );
+      }
     }
   }
 
@@ -161,6 +165,7 @@ class _TaskScreenState extends State<TaskScreen> {
       backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       floatingActionButton: FloatingActionButton(
         onPressed: () async {
+          final messenger = ScaffoldMessenger.of(context);
           final result = await Navigator.push(
             context,
             MaterialPageRoute(
@@ -169,9 +174,9 @@ class _TaskScreenState extends State<TaskScreen> {
             ),
           );
 
-          if (result == true) {
+          if (result == true && mounted) {
             _loadTasks();
-            ScaffoldMessenger.of(context).showSnackBar(
+            messenger.showSnackBar(
               const SnackBar(
                 content: Text('Task created successfully'),
                 backgroundColor: Colors.green,

--- a/lib/screens/tickets/ticket_screen.dart
+++ b/lib/screens/tickets/ticket_screen.dart
@@ -152,6 +152,7 @@ class _TicketScreenState extends State<TicketScreen> {
       backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       floatingActionButton: FloatingActionButton(
         onPressed: () async {
+          final messenger = ScaffoldMessenger.of(context);
           final result = await Navigator.push(
             context,
             MaterialPageRoute(
@@ -160,9 +161,9 @@ class _TicketScreenState extends State<TicketScreen> {
             ),
           );
 
-          if (result == true) {
+          if (result == true && mounted) {
             refreshTickets();
-            ScaffoldMessenger.of(context).showSnackBar(
+            messenger.showSnackBar(
               const SnackBar(
                 content: Text('Ticket created successfully'),
                 backgroundColor: Colors.green,

--- a/lib/screens/workspace/workspace_screen.dart
+++ b/lib/screens/workspace/workspace_screen.dart
@@ -80,12 +80,14 @@ class _WorkspaceScreenState extends State<WorkspaceScreen>
         // Force refresh of the task screen
         TaskScreen.refreshTasks();
 
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(
-            content: Text('Task created successfully'),
-            backgroundColor: Colors.green,
-          ),
-        );
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text('Task created successfully'),
+              backgroundColor: Colors.green,
+            ),
+          );
+        }
       }
     });
   }
@@ -106,12 +108,14 @@ class _WorkspaceScreenState extends State<WorkspaceScreen>
         // Force refresh of the ticket screen
         TicketScreen.refreshTickets();
 
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(
-            content: Text('Ticket created successfully'),
-            backgroundColor: Colors.green,
-          ),
-        );
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text('Ticket created successfully'),
+              backgroundColor: Colors.green,
+            ),
+          );
+        }
       }
     });
   }
@@ -132,12 +136,14 @@ class _WorkspaceScreenState extends State<WorkspaceScreen>
         // Force refresh of the meeting screen
         MeetingScreen.refreshMeetings();
 
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(
-            content: Text('Meeting created successfully'),
-            backgroundColor: Colors.green,
-          ),
-        );
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text('Meeting created successfully'),
+              backgroundColor: Colors.green,
+            ),
+          );
+        }
       }
     });
   }


### PR DESCRIPTION
## Summary

Fixes #223

Resolves `use_build_context_synchronously` lint warnings in three screens where `ScaffoldMessenger.of(context)` was called after an `await` without a `mounted` guard.

## Problem

After an `await` (e.g., `await Navigator.push(...)`), the widget may have been disposed. Calling `ScaffoldMessenger.of(context)` on a stale `BuildContext` can cause a runtime crash:

```
FlutterError: Looking up a deactivated widget's ancestor is unsafe.
```

The analyzer correctly flagged these with `use_build_context_synchronously`.

## Files Changed

| File | Issue |
|------|-------|
| `lib/screens/tasks/task_screen.dart` | `ScaffoldMessenger.of(context)` after `await Navigator.push` in FAB `onPressed` |
| `lib/screens/tickets/ticket_screen.dart` | Same pattern in FAB `onPressed` |
| `lib/screens/workspace/workspace_screen.dart` | Three `.then((result) async {})` callbacks after `await` calls |

## Fix Applied

Two complementary techniques used per Flutter best practices:

1. **Pre-capture the messenger** before the `await`:
   ```dart
   final messenger = ScaffoldMessenger.of(context);
   final result = await Navigator.push(...);
   if (result == true && mounted) {
     messenger.showSnackBar(...); // safe: captured before await
   }
   ```

2. **`mounted` guard in `.then()` callbacks** (workspace screen):
   ```dart
   .then((result) async {
     if (result == true) {
       await supabaseService.loadTeamMembers(...);
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(...);
       }
     }
   });
   ```

## Before / After

**Before** (`flutter analyze`):
```
info - Don't use 'BuildContext's across async gaps - task_screen.dart:178 - use_build_context_synchronously
info - Don't use 'BuildContext's across async gaps - ticket_screen.dart:165 - use_build_context_synchronously
info - Don't use 'BuildContext's across async gaps - workspace_screen.dart:83 - use_build_context_synchronously
info - Don't use 'BuildContext's across async gaps - workspace_screen.dart:109 - use_build_context_synchronously
info - Don't use 'BuildContext's across async gaps - workspace_screen.dart:135 - use_build_context_synchronously
```

**After** (`flutter analyze lib/screens/tasks/task_screen.dart lib/screens/tickets/ticket_screen.dart lib/screens/workspace/workspace_screen.dart`):
```
23 issues found.
```
Zero `use_build_context_synchronously` warnings remaining in these files.

## Checklist

- [x] `flutter analyze` run — no new warnings introduced
- [x] All `use_build_context_synchronously` warnings in the three files resolved
- [x] Fix follows Flutter official guidance (pre-capture or `mounted` check)
- [x] No logic changes — only safety guards added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential crashes when displaying success or error notifications after navigating away from screens.
  * Improved stability when creating tasks, tickets, or meetings by ensuring notifications only display when screens are active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->