### PR TITLE
fix: guard BuildContext usage across async gaps in auth and profile screens

### DIFF
--- a/lib/screens/auth/verify_otp_screen.dart
+++ b/lib/screens/auth/verify_otp_screen.dart
@@ -194,6 +194,7 @@ class _VerifyOTPScreenState extends State<VerifyOTPScreen> {
       _errorMessage = null;
     });
 
+    final messenger = ScaffoldMessenger.of(context);
 
     try {
       final result = await _supabaseService.resendVerificationEmail(
@@ -201,8 +202,8 @@ class _VerifyOTPScreenState extends State<VerifyOTPScreen> {
         type: widget.verifyType,
       );
 
-      if (result['success']) {
-        ScaffoldMessenger.of(context).showSnackBar(
+      if (result['success'] && mounted) {
+        messenger.showSnackBar(
           const SnackBar(
             content: Text('Verification code resent successfully. Please check your inbox and spam folder.'),
             backgroundColor: Colors.green,

--- a/lib/screens/profile/profile_screen.dart
+++ b/lib/screens/profile/profile_screen.dart
@@ -111,6 +111,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
     if (shouldLogout != true) return;
 
     // modal loading dialog
+    if (!mounted) return;
     showDialog(
       context: context,
       barrierDismissible: false,


### PR DESCRIPTION
## Summary

Fixes #224

Resolves `use_build_context_synchronously` lint warnings in `verify_otp_screen.dart` and `profile_screen.dart` where `BuildContext` was used after `await` without adequate guards.

## Problem

Using `BuildContext` after an `await` without checking `mounted` can cause runtime crashes when the widget has been disposed:

```
FlutterError: Looking up a deactivated widget's ancestor is unsafe.
```

### `verify_otp_screen.dart:205`
```dart
// Before — ScaffoldMessenger.of(context) called after await, no mounted check
final result = await _supabaseService.resendVerificationEmail(...);
if (result['success']) {
  ScaffoldMessenger.of(context).showSnackBar(...);  // ❌ unsafe
}
```

### `profile_screen.dart:115`
```dart
// Before — showDialog(context: context) called after await showDialog,
// no mounted check before the second dialog
final shouldLogout = await showDialog<bool>(...);
if (shouldLogout != true) return;
showDialog(context: context, ...);  // ❌ context may be stale
```

## Fix

### `verify_otp_screen.dart`
Pre-capture `ScaffoldMessenger` before the `await` and add `mounted` guard:
```dart
final messenger = ScaffoldMessenger.of(context);  // captured before await
final result = await _supabaseService.resendVerificationEmail(...);
if (result['success'] && mounted) {
  messenger.showSnackBar(...);  // ✅ safe
}
```

### `profile_screen.dart`
Add `if (!mounted) return;` guard before the second `showDialog`:
```dart
final shouldLogout = await showDialog<bool>(...);
if (shouldLogout != true) return;
if (!mounted) return;  // ✅ early exit if widget disposed
showDialog(context: context, ...);
```

## Before / After

**Before** (`flutter analyze`):
```
info - Don't use 'BuildContext's across async gaps - verify_otp_screen.dart:205 - use_build_context_synchronously
info - Don't use 'BuildContext's across async gaps - profile_screen.dart:115 - use_build_context_synchronously
```

**After** (`flutter analyze lib/screens/auth/verify_otp_screen.dart lib/screens/profile/profile_screen.dart`):
```
9 issues found.
```
Zero `use_build_context_synchronously` warnings in these files.

## Checklist

- [x] `flutter analyze` run — no new warnings introduced
- [x] All `use_build_context_synchronously` warnings resolved in both files
- [x] Fix follows Flutter official guidance (pre-capture or early `mounted` return)
- [x] No logic changes — only safety guards added