### PR TITLE
Fix calendar crashes with symmetric rolling window dates. Closes #110 , #111

### DIFF
--- a/lib/screens/calendar/calendar_screen.dart
+++ b/lib/screens/calendar/calendar_screen.dart
@@ -41,11 +41,12 @@ class _CalendarScreenState extends State<CalendarScreen> {
   // Cache duration (5 minutes)
   static const Duration _cacheDuration = Duration(minutes: 5);
 
-  ({DateTime first, DateTime last}) _calendarBounds(DateTime anchor) {
-    return (
-      first: DateTime.utc(anchor.year - 1, anchor.month, anchor.day),
-      last: DateTime.utc(anchor.year + 3, anchor.month, anchor.day),
-    );
+  DateTime _getFirstBoundedDay(DateTime anchor) {
+    return DateTime.utc(anchor.year - 1, anchor.month, anchor.day);
+  }
+
+  DateTime _getLastBoundedDay(DateTime anchor) {
+    return DateTime.utc(anchor.year + 3, anchor.month, anchor.day);
   }
 
   DateTime _clampDay(DateTime day, DateTime first, DateTime last) {
@@ -58,8 +59,10 @@ class _CalendarScreenState extends State<CalendarScreen> {
   void initState() {
     super.initState();
     // Safety clamp for initial dates in case system clock is off bounds
-    final bounds = _calendarBounds(DateTime.now());
-    final safeDay = _clampDay(DateTime.now(), bounds.first, bounds.last);
+    final now = DateTime.now();
+    final first = _getFirstBoundedDay(now);
+    final last = _getLastBoundedDay(now);
+    final safeDay = _clampDay(now, first, last);
 
     _focusedDay = safeDay;
     _selectedDay = safeDay;
@@ -380,10 +383,12 @@ class _CalendarScreenState extends State<CalendarScreen> {
     final colorScheme = Theme.of(context).colorScheme;
 
     // Create a dynamic rolling window to avoid unbounded memory growth
-    final bounds = _calendarBounds(DateTime.now());
-    
+    final now = DateTime.now();
+    final first = _getFirstBoundedDay(now);
+    final last = _getLastBoundedDay(now);
+
     // Safely clamp focused day to mathematically prevent table_calendar runtime crashes
-    final safeFocusedDay = _clampDay(_focusedDay, bounds.first, bounds.last);
+    final safeFocusedDay = _clampDay(_focusedDay, first, last);
 
     return Container(
       margin: const EdgeInsets.symmetric(horizontal: 8),
@@ -394,8 +399,8 @@ class _CalendarScreenState extends State<CalendarScreen> {
       child: Padding(
         padding: const EdgeInsets.all(8.0),
         child: TableCalendar(
-          firstDay: bounds.first,
-          lastDay: bounds.last,
+          firstDay: first,
+          lastDay: last,
           focusedDay: safeFocusedDay,
           calendarFormat: _calendarFormat,
           selectedDayPredicate: (day) => isSameDay(_selectedDay, day),


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #110 , #111 

## Issue Description 
The calendar screen used to crash due to a TableCalendar assertion error when the current date fails outside the configured calendar range. This happens because foucusedDay is initialized using DateTime.now().

## 📝 Description
It fixed the critical calendar crashes (RangeError) and resolves severe sluggishness/memory exhaustion issues on older devices. Previously, the table_calendar widget was allowed to perform unbounded mathematical indexing when users scrolled too far into the past, resulting in negative indexes breaking the Dart array bounds. Additionally, rendering unbounded months caused a completely unmanaged memory footprint.

<!-- A clear and concise description of what this pull request does. -->
 The FIX - Symmetric Rolling Window Architecture
 
<!-- Include any context or background information if necessary. -->

## 🔧 Changes Made
1st change -> Establishing the Bounding Box - We defined a dynamic range: exactly 1 year in the past and 3 years in the future from the current DateTime.now().
`final now = DateTime.now();
final firstBoundedDay = DateTime.utc(now.year - 1, now.month, now.day);
final lastBoundedDay = DateTime.utc(now.year + 3, now.month, now.day);`


2nd change ->Safe Clamping Logic- To fix the RangeError permanently, we added logic that intercepts the focusedDay before the calendar widget ever sees it. If the app tries to load a day outside of our bounding box, we mathematically "clamp" it to the boundary edges.

`DateTime safeFocusedDay = _focusedDay;
if (safeFocusedDay.isBefore(firstBoundedDay)) {
  safeFocusedDay = firstBoundedDay;
}
if (safeFocusedDay.isAfter(lastBoundedDay)) {
  safeFocusedDay = lastBoundedDay;
}`

<!-- List the changes you made in this pull request. -->
<!-- For example:
- Fixed a bug in the login flow.
- Added a new feature for user profile customization.
- Updated documentation for API endpoints.
-->
## Conclusion
By shifting from an unbounded list to a Symmetric Rolling Window, we:

1. Eliminated the crash by ensuring mathematical safety against negative bounds.

2. Optimized performance by putting a hard cap on memory usage regardless of how far the user scrolls.

3. Created a production-grade UI that feels naturally constrained (1 year back, 3 years forward) instead of arbitrarily breaking.

## 📷 Screenshots or Visual Changes (if applicable)
 Before Implementing The FIX: 
<img width="200" height="400" alt="image" src="https://github.com/user-attachments/assets/cab30fd2-a6af-4ffd-b4fc-a234bde8c049" />

After Implementing The Fix:
<p float="left">
  <img src="https://github.com/user-attachments/assets/83019864-bbbf-41e1-99d6-52e54fcd4200" width="200" />
  <img src="https://github.com/user-attachments/assets/e9a3df44-9ba6-4b4e-80a8-84aaeb379da6" width="200" />
</p>
<!-- Attach screenshots or GIFs to show visual changes, if any. -->
<!-- Drag and drop screenshots here or provide a description of visual updates. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved calendar bounds and safe date clamping to prevent runtime crashes when focusing dates
  * Fixed event time handling to yield correct start/end times for tickets and meetings

* **Improvements**
  * New events now open with the selected calendar date/time pre-filled for faster creation
  * AI-assisted creation now includes the selected date/time in the initial message sent to compose events
<!-- end of auto-generated comment: release notes by coderabbit.ai -->