### PR TITLE
fix: replace hardcoded colors in AuthScreenWrapper with theme-aware colors

### DIFF
--- a/lib/widgets/custom_widgets.dart
+++ b/lib/widgets/custom_widgets.dart
@@ -147,7 +147,7 @@ class AuthScreenWrapper extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: const Color(0xFF1A1A1A),
+      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       body: SafeArea(
         child: SingleChildScrollView(
           padding: const EdgeInsets.all(24),
@@ -157,16 +157,16 @@ class AuthScreenWrapper extends StatelessWidget {
               const SizedBox(height: 40),
               Text(
                 title,
-                style: const TextStyle(
-                  fontSize: 32,
+                style: Theme.of(context).textTheme.headlineLarge?.copyWith(
                   fontWeight: FontWeight.bold,
-                  color: Colors.white,
                 ),
               ),
               const SizedBox(height: 8),
               Text(
                 subtitle,
-                style: TextStyle(fontSize: 16, color: Colors.grey.shade400),
+                style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
               ),
               const SizedBox(height: 30),
               ...children,


### PR DESCRIPTION
Fixes #211

## Problem
AuthScreenWrapper had 3 hardcoded colors preventing 
theme adaptation:
- Background: const Color(0xFF1A1A1A) — always dark
- Title: Colors.white — invisible in light mode
- Subtitle: Colors.grey.shade400 — ignores theme

## Fix
- Background: Theme.of(context).scaffoldBackgroundColor
- Title: Theme.of(context).textTheme.headlineLarge
- Subtitle: Theme.of(context).colorScheme.onSurfaceVariant

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Authentication screen now respects the app's theme settings for colors and typography, ensuring consistent appearance across different themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->