### PR TITLE
fix: correct Map vs bool comparison in _updateTaskStatus

### DIFF
--- a/lib/screens/tasks/task_detail_screen.dart
+++ b/lib/screens/tasks/task_detail_screen.dart
@@ -72,13 +72,13 @@ class _TaskDetailScreenState extends State<TaskDetailScreen> {
 
   Future<void> _updateTaskStatus(String status) async {
     try {
-      final success = await _supabaseService.updateTaskStatus(
+      final result = await _supabaseService.updateTaskStatus(
         taskId: widget.taskId,
         status: status,
       );
 
       if (mounted) {
-        if (success == true) {
+        if (result['success'] == true) {
           // Reload task details
           await _loadTaskDetails();
           ScaffoldMessenger.of(context).showSnackBar(


### PR DESCRIPTION
## Summary

Closes #222

`_updateTaskStatus()` stored the return value of `updateTaskStatus()` in `success`, then compared `success == true`. But `updateTaskStatus()` returns `Future<Map<String, dynamic>>`, not `bool` — so `Map == bool` is always `false` in Dart. The success SnackBar was **unreachable** and the failure SnackBar showed on every status update.

## Root cause

```dart
// Before — wrong type comparison
final success = await _supabaseService.updateTaskStatus(...);
if (success == true) { // ❌ Map<String,dynamic> == bool → always false
```

## Fix

```dart
// After — read 'success' key from returned Map
final result = await _supabaseService.updateTaskStatus(...);
if (result['success'] == true) { // ✅ correct
```

## Changes

- `lib/screens/tasks/task_detail_screen.dart:75` — renamed `success` → `result`
- `lib/screens/tasks/task_detail_screen.dart:81` — changed `success == true` → `result['success'] == true`

This matches the pattern already used on line 186 in the same file (`result['success']`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced task status update feedback with improved success and error notifications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AOSSIE-Org/Ell-ena/pull/251)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->