### PR TITLE
fix: enable text wrapping in chat input field

### DIFF
--- a/lib/screens/chat/chat_screen.dart
+++ b/lib/screens/chat/chat_screen.dart
@@ -1319,13 +1319,16 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
                     child: TextField(
                       controller: _messageController,
                       style: TextStyle(color: colorScheme.onSurface),
+                      minLines: 1,
+                      maxLines: 5,
+                      keyboardType: TextInputType.multiline,
+                      textInputAction: TextInputAction.newline,
                       decoration: InputDecoration(
                         hintText: 'Type your message...',
                         hintStyle:
                             TextStyle(color: colorScheme.onSurfaceVariant),
                         border: InputBorder.none,
                       ),
-                      onSubmitted: (_) => _sendMessage(),
                     ),
                   ),
                 ),


### PR DESCRIPTION
## Summary

Closes #175

Chat input forced horizontal scrolling on long messages. Fixed by making the field grow vertically (1–5 lines) like Gemini/ChatGPT.

## Changes

**`lib/screens/chat/chat_screen.dart`**
- Added `minLines: 1` — starts as single line
- Added `maxLines: 5` — expands up to 5 lines, then scrolls vertically
- Added `keyboardType: TextInputType.multiline` — enables soft-keyboard newline
- Added `textInputAction: TextInputAction.newline` — Enter key inserts newline; send uses the send button
- Removed `onSubmitted` (Enter no longer auto-sends; use the send button)

## Before / After

| | Before | After |
|---|---|---|
| Long message | Text scrolls horizontally off-screen | Text wraps to next line, stays visible |
| Send action | Enter key submits | Send button submits (Enter = newline) |