### PR TITLE
fix: add mounted check after async gap in OTP resend

### DIFF
--- a/lib/screens/auth/verify_otp_screen.dart
+++ b/lib/screens/auth/verify_otp_screen.dart
@@ -201,6 +201,7 @@ class _VerifyOTPScreenState extends State<VerifyOTPScreen> {
         type: widget.verifyType,
       );
 
+      if (!mounted) return;
       if (result['success']) {
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(


### PR DESCRIPTION
## Summary

Closes #224

`ScaffoldMessenger.of(context)` was called after `await resendVerificationEmail()` in `verify_otp_screen.dart` without checking `if (mounted)`. If the user navigated back while the async call was in flight, the widget would be disposed and calling `ScaffoldMessenger.of(context)` would crash with: `"Looking up a deactivated widget's ancestor is unsafe"`.

## Fix

Added `if (!mounted) return;` immediately after the `await` and before any context usage in the resend flow.

```dart
// Before
final result = await _supabaseService.resendVerificationEmail(...);
if (result['success']) {
  ScaffoldMessenger.of(context).showSnackBar(...); // ❌ no mounted check

// After
final result = await _supabaseService.resendVerificationEmail(...);
if (!mounted) return; // ✅ guard added
if (result['success']) {
  ScaffoldMessenger.of(context).showSnackBar(...);
```

## File changed

- `lib/screens/auth/verify_otp_screen.dart` — line 204 (after resend await)