### PR TITLE
fix: use theme-aware text colors in meeting_insights_screen for light mode visibility

### DIFF
--- a/lib/screens/meetings/meeting_insights_screen.dart
+++ b/lib/screens/meetings/meeting_insights_screen.dart
@@ -338,14 +338,14 @@ class _MeetingInsightsScreenState extends State<MeetingInsightsScreen>
                   children: [
                     Text(
                       speaker,
-                      style: const TextStyle(
-                          color: Colors.white, fontWeight: FontWeight.bold),
+                      style: TextStyle(
+                          color: Theme.of(context).colorScheme.onSurface, fontWeight: FontWeight.bold),
                     ),
                     const SizedBox(height: 4),
                     Text(
                       text,
                       style:
-                          const TextStyle(color: Colors.white70, height: 1.3),
+                          TextStyle(color: Theme.of(context).colorScheme.onSurfaceVariant, height: 1.3),
                     ),
                   ],
                 ),


### PR DESCRIPTION
## Description

Fixes inaccessible white-on-white text in light mode by replacing hardcoded `Colors.white` / `Colors.white70` with theme-aware `onSurface` / `onSurfaceVariant` colors.

## Changes
- `meeting_insights_screen.dart`: switched to `Theme.of(context).colorScheme.onSurface` and `onSurfaceVariant`

Closes #263

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated text colors in meeting transcription views to align with the app's current theme, ensuring consistent visual appearance across speaker names and transcription text.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AOSSIE-Org/Ell-ena/pull/264?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->