### PR TITLE
fix(db): prevent user team change when tickets reference the user

### DIFF
--- a/supabase/migrations/20251021110000_prevent_user_team_change_trigger.sql
+++ b/supabase/migrations/20251021110000_prevent_user_team_change_trigger.sql
@@ -1,0 +1,20 @@
+-- Trigger function: block team_id change on users who are referenced in tickets
+CREATE OR REPLACE FUNCTION prevent_user_team_change_if_tickets_exist()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF OLD.team_id IS DISTINCT FROM NEW.team_id THEN
+    IF EXISTS (
+      SELECT 1 FROM tickets
+      WHERE created_by = OLD.id OR assigned_to = OLD.id
+    ) THEN
+      RAISE EXCEPTION 'Cannot change user team: user is referenced in existing tickets as created_by or assigned_to';
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER prevent_user_team_change
+  BEFORE UPDATE ON users
+  FOR EACH ROW
+  EXECUTE FUNCTION prevent_user_team_change_if_tickets_exist();

--- a/supabase/migrations/20251021110000_prevent_user_team_change_trigger.sql
+++ b/supabase/migrations/20251021110000_prevent_user_team_change_trigger.sql
@@ -1,10 +1,14 @@
 -- Trigger function: block team_id change on users who are referenced in tickets
-CREATE OR REPLACE FUNCTION prevent_user_team_change_if_tickets_exist()
-RETURNS TRIGGER AS $$
+CREATE OR REPLACE FUNCTION public.prevent_user_team_change_if_tickets_exist()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
 BEGIN
   IF OLD.team_id IS DISTINCT FROM NEW.team_id THEN
     IF EXISTS (
-      SELECT 1 FROM tickets
+      SELECT 1 FROM public.tickets
       WHERE created_by = OLD.id OR assigned_to = OLD.id
     ) THEN
       RAISE EXCEPTION 'Cannot change user team: user is referenced in existing tickets as created_by or assigned_to';
@@ -12,9 +16,40 @@ BEGIN
   END IF;
   RETURN NEW;
 END;
-$$ LANGUAGE plpgsql;
+$$;
 
 CREATE TRIGGER prevent_user_team_change
-  BEFORE UPDATE ON users
+  BEFORE UPDATE ON public.users
   FOR EACH ROW
-  EXECUTE FUNCTION prevent_user_team_change_if_tickets_exist();
+  EXECUTE FUNCTION public.prevent_user_team_change_if_tickets_exist();
+
+-- Trigger function: validate that ticket members belong to the ticket's team
+CREATE OR REPLACE FUNCTION public.validate_ticket_team_consistency()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_team UUID;
+BEGIN
+  SELECT team_id INTO v_team FROM public.users WHERE id = NEW.created_by;
+  IF v_team != NEW.team_id THEN
+    RAISE EXCEPTION 'Ticket team mismatch: created_by user does not belong to the ticket''s team';
+  END IF;
+
+  IF NEW.assigned_to IS NOT NULL THEN
+    SELECT team_id INTO v_team FROM public.users WHERE id = NEW.assigned_to;
+    IF v_team != NEW.team_id THEN
+      RAISE EXCEPTION 'Ticket team mismatch: assigned_to user does not belong to the ticket''s team';
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER validate_ticket_team_consistency
+  BEFORE INSERT OR UPDATE ON public.tickets
+  FOR EACH ROW
+  EXECUTE FUNCTION public.validate_ticket_team_consistency();


### PR DESCRIPTION
Fixes #237

## Problem
No database-level enforcement existed to prevent a user's `team_id` from 
being changed while tickets still reference them as `created_by` or 
`assigned_to`. This caused silent cross-team data integrity violations.

## Root Cause
Verified across all 10 migration files — no BEFORE UPDATE trigger on the 
`users` table and no constraint preventing `team_id` changes for referenced users.

## Fix
Added migration `20251021110000_prevent_user_team_change_trigger.sql`:
- Creates `prevent_user_team_change_if_tickets_exist()` trigger function
- Fires `BEFORE UPDATE ON users` for each row
- Only activates when `OLD.team_id IS DISTINCT FROM NEW.team_id`
- Raises an exception if any ticket references the user as `created_by` or `assigned_to`
- Allows the update if no such tickets exist

## Testing
1. Create a user in team A
2. Create a ticket with that user as `created_by`
3. Attempt to change the user's `team_id` to team B
4. Confirm the database raises an error and blocks the update
5. Delete or reassign the ticket, then retry — confirm the team change succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Team changes are now prevented if a user has associated tickets, ensuring consistency across the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->