### PR TITLE
Integrate go_router for URL-based navigation

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,18 +2,17 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart'
     hide ChangeNotifierProvider;
 import 'package:provider/provider.dart';
-import 'screens/splash_screen.dart';
-import 'screens/home/home_screen.dart';
-import 'screens/chat/chat_screen.dart';
-import 'services/navigation_service.dart';
-import 'services/supabase_service.dart';
-import 'services/ai_service.dart';
 import 'providers/theme_provider.dart';
-import 'theme/theme_controller.dart';
+import 'router/app_router.dart';
+import 'services/ai_service.dart';
+import 'services/supabase_service.dart';
 import 'theme/app_themes.dart';
+import 'theme/theme_controller.dart';
+import 'utils/url_strategy.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  configureAppUrlStrategy();
 
   try {
     await SupabaseService().initialize();
@@ -21,115 +20,79 @@ void main() async {
   } catch (e) {
     debugPrint('Error initializing services: $e');
   }
-  
+
   final themeController = await ThemeController.create();
 
-runApp(
-  WidgetsBindingObserverWidget(
-    child: ProviderScope(
-      overrides: [
-        themeControllerProvider.overrideWith((ref) => themeController),
-      ],
-      child: ChangeNotifierProvider<ThemeController>.value(
-        value: themeController,
-        child: const MyApp(),
+  runApp(
+    WidgetsBindingObserverWidget(
+      child: ProviderScope(
+        overrides: [
+          themeControllerProvider.overrideWith((ref) => themeController),
+        ],
+        child: ChangeNotifierProvider<ThemeController>.value(
+          value: themeController,
+          child: const MyApp(),
+        ),
       ),
     ),
-  ),
-);
-
+  );
 }
+
 class MyApp extends ConsumerWidget {
   const MyApp({super.key});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final themeController = ref.watch(themeControllerProvider);
-    return MaterialApp(
+    final router = ref.watch(appRouterProvider);
+
+    return MaterialApp.router(
       title: 'Ell-ena',
       debugShowCheckedModeBanner: false,
-      navigatorKey: NavigationService().navigatorKey,
-      navigatorObservers: <NavigatorObserver>[AppRouteObserver.instance],
       theme: lightTheme,
       darkTheme: darkTheme,
       themeMode: themeController.flutterThemeMode,
-      home: const SplashScreen(),
-      onGenerateRoute: (settings) {
-        if (settings.name == '/') {
-          return MaterialPageRoute(
-            builder: (context) => const SplashScreen(),
-            settings: settings,
-          );
-        } else if (settings.name == '/home') {
-          final args = (settings.arguments is Map<String, dynamic>) 
-              ? settings.arguments as Map<String, dynamic> 
-              : null;
-              
-          return MaterialPageRoute(
-            builder: (context) => HomeScreen(arguments: args),
-            settings: settings,
-          );
-        } else if (settings.name == '/chat') {
-          final args = (settings.arguments is Map<String, dynamic>) 
-              ? settings.arguments as Map<String, dynamic> 
-              : null;
-              
-          return MaterialPageRoute(
-            builder: (context) => ChatScreen(arguments: args),
-            settings: settings,
-          );
-        }
-        return null;
-      },
+      routerConfig: router,
     );
   }
 }
 
 class WidgetsBindingObserverWidget extends StatefulWidget {
-    final Widget child;
+  final Widget child;
 
-    const WidgetsBindingObserverWidget({
-      super.key,
-      required this.child,
-    });
+  const WidgetsBindingObserverWidget({
+    super.key,
+    required this.child,
+  });
 
-    @override
-    State<WidgetsBindingObserverWidget> createState() =>
-        _WidgetsBindingObserverWidgetState();
-  }
-
-  class _WidgetsBindingObserverWidgetState
-      extends State<WidgetsBindingObserverWidget>
-      with WidgetsBindingObserver {
-
-    @override
-    void initState() {
-      super.initState();
-      WidgetsBinding.instance.addObserver(this);
-    }
-
-    @override
-    void didChangeAppLifecycleState(AppLifecycleState state) {
-      if (state == AppLifecycleState.detached) {
-        SupabaseService().dispose(); // ✅ ONLY IMPORTANT LINE
-      }
-    }
-
-    @override
-    void dispose() {
-      WidgetsBinding.instance.removeObserver(this);
-      super.dispose();
-    }
-
-    @override
-    Widget build(BuildContext context) {
-      return widget.child;
-    }
-  }
-
-// Simple singleton RouteObserver to allow screens to refresh on focus
-class AppRouteObserver extends RouteObserver<ModalRoute<void>> {
-  AppRouteObserver._();
-  static final AppRouteObserver instance = AppRouteObserver._();
+  @override
+  State<WidgetsBindingObserverWidget> createState() =>
+      _WidgetsBindingObserverWidgetState();
 }
 
+class _WidgetsBindingObserverWidgetState
+    extends State<WidgetsBindingObserverWidget> with WidgetsBindingObserver {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.detached) {
+      SupabaseService().dispose();
+    }
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return widget.child;
+  }
+}

--- a/lib/providers/navigation/models/home_tab.dart
+++ b/lib/providers/navigation/models/home_tab.dart
@@ -1,0 +1,15 @@
+/// Primary destinations for [HomeScreen] bottom navigation.
+enum HomeTab {
+  dashboard,
+  calendar,
+  workspace,
+  chat,
+  profile;
+
+  static HomeTab fromIndex(int index) {
+    if (index < 0 || index >= HomeTab.values.length) {
+      return HomeTab.dashboard;
+    }
+    return HomeTab.values[index];
+  }
+}

--- a/lib/providers/navigation_provider.dart
+++ b/lib/providers/navigation_provider.dart
@@ -1,8 +1,0 @@
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-
-import 'navigation/models/home_tab.dart';
-
-/// Selected tab for [HomeScreen] bottom navigation.
-final homeTabProvider = StateProvider<HomeTab>(
-  (ref) => HomeTab.dashboard,
-);

--- a/lib/providers/navigation_provider.dart
+++ b/lib/providers/navigation_provider.dart
@@ -1,8 +1,8 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-/// Bottom navigation index for the home shell ([HomeScreen]).
-///
-/// 0: Dashboard, 1: Calendar, 2: Workspace, 3: Chat, 4: Profile.
-///
-/// Not wired to [HomeScreen] yet — foundation for future migration.
-final homeTabIndexProvider = StateProvider<int>((ref) => 0);
+import 'navigation/models/home_tab.dart';
+
+/// Selected tab for [HomeScreen] bottom navigation.
+final homeTabProvider = StateProvider<HomeTab>(
+  (ref) => HomeTab.dashboard,
+);

--- a/lib/router/app_route_observer.dart
+++ b/lib/router/app_route_observer.dart
@@ -1,0 +1,8 @@
+import 'package:flutter/material.dart';
+
+/// Allows screens to refresh when their route regains focus.
+class AppRouteObserver extends RouteObserver<ModalRoute<void>> {
+  AppRouteObserver._();
+
+  static final AppRouteObserver instance = AppRouteObserver._();
+}

--- a/lib/router/app_router.dart
+++ b/lib/router/app_router.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../screens/home/home_screen.dart';
+import 'app_route_observer.dart';
+import '../screens/splash_screen.dart';
+import '../services/navigation_service.dart';
+import 'app_routes.dart';
+
+final appRouterProvider = Provider<GoRouter>((ref) {
+  final router = GoRouter(
+    navigatorKey: NavigationService().navigatorKey,
+    initialLocation: AppRoutes.splash,
+    observers: <NavigatorObserver>[AppRouteObserver.instance],
+    routes: <RouteBase>[
+      GoRoute(
+        path: AppRoutes.splash,
+        builder: (context, state) => const SplashScreen(),
+      ),
+      ShellRoute(
+        builder: (context, state, child) {
+          return HomeScreen(
+            location: state.uri.path,
+            queryParameters: state.uri.queryParameters,
+          );
+        },
+        routes: _shellTabRoutes,
+      ),
+    ],
+  );
+
+  NavigationService().setRouter(router);
+  return router;
+});
+
+final List<GoRoute> _shellTabRoutes = <GoRoute>[
+  GoRoute(
+    path: AppRoutes.home,
+    pageBuilder: _shellPage,
+  ),
+  GoRoute(
+    path: AppRoutes.calendar,
+    pageBuilder: _shellPage,
+  ),
+  GoRoute(
+    path: AppRoutes.workspace,
+    pageBuilder: _shellPage,
+  ),
+  GoRoute(
+    path: AppRoutes.tasks,
+    pageBuilder: _shellPage,
+  ),
+  GoRoute(
+    path: AppRoutes.tickets,
+    pageBuilder: _shellPage,
+  ),
+  GoRoute(
+    path: AppRoutes.meetings,
+    pageBuilder: _shellPage,
+  ),
+  GoRoute(
+    path: AppRoutes.chat,
+    pageBuilder: _shellPage,
+  ),
+  GoRoute(
+    path: AppRoutes.profile,
+    pageBuilder: _shellPage,
+  ),
+];
+
+Page<void> _shellPage(BuildContext context, GoRouterState state) {
+  return const NoTransitionPage<void>(child: SizedBox.shrink());
+}

--- a/lib/router/app_routes.dart
+++ b/lib/router/app_routes.dart
@@ -1,0 +1,91 @@
+import '../providers/navigation/models/home_tab.dart';
+
+/// Typed route paths for Ell-ena navigation.
+class AppRoutes {
+  AppRoutes._();
+  static const splash = '/';
+  static const home = '/home';
+  static const calendar = '/calendar';
+  static const workspace = '/workspace';
+  static const tasks = '/tasks';
+  static const tickets = '/tickets';
+  static const meetings = '/meetings';
+  static const chat = '/chat';
+  static const profile = '/profile';
+
+  static const shellPaths = <String>{
+    home,
+    calendar,
+    workspace,
+    tasks,
+    tickets,
+    meetings,
+    chat,
+    profile,
+  };
+
+  /// Primary shell destinations exposed through [HomeTab] bottom navigation.
+  static String pathForHomeTab(HomeTab tab) {
+    switch (tab) {
+      case HomeTab.dashboard:
+        return home;
+      case HomeTab.calendar:
+        return calendar;
+      case HomeTab.workspace:
+        return workspace;
+      case HomeTab.chat:
+        return chat;
+      case HomeTab.profile:
+        return profile;
+    }
+  }
+
+  static HomeTab homeTabForPath(String path) {
+    switch (path) {
+      case calendar:
+        return HomeTab.calendar;
+      case workspace:
+      case tasks:
+      case tickets:
+      case meetings:
+        return HomeTab.workspace;
+      case chat:
+        return HomeTab.chat;
+      case profile:
+        return HomeTab.profile;
+      case home:
+      default:
+        return HomeTab.dashboard;
+    }
+  }
+
+  /// Workspace TabBar index for deep-link paths, or null for generic workspace.
+  static int? workspaceTabIndexForPath(String path) {
+    switch (path) {
+      case tasks:
+        return 0;
+      case tickets:
+        return 1;
+      case meetings:
+        return 2;
+      default:
+        return null;
+    }
+  }
+
+  static String pathForWorkspaceTabIndex(int index) {
+    switch (index) {
+      case 0:
+        return tasks;
+      case 1:
+        return tickets;
+      case 2:
+        return meetings;
+      default:
+        return workspace;
+    }
+  }
+
+  static HomeTab homeTabForScreenIndex(int index) =>
+      HomeTab.fromIndex(index);
+}

--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -1,73 +1,32 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
-import '../../widgets/custom_widgets.dart';
-import '../../services/navigation_service.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../providers/navigation/models/home_tab.dart';
+import '../../providers/navigation_provider.dart';
 import '../workspace/workspace_screen.dart';
 import '../calendar/calendar_screen.dart';
 import '../profile/profile_screen.dart';
 import '../chat/chat_screen.dart';
 import 'dashboard_screen.dart';
 
-class HomeScreen extends StatefulWidget {
+class HomeScreen extends ConsumerStatefulWidget {
   final Map<String, dynamic>? arguments;
 
   const HomeScreen({super.key, this.arguments});
 
   @override
-  State<HomeScreen> createState() => _HomeScreenState();
+  ConsumerState<HomeScreen> createState() => _HomeScreenState();
 }
 
-class _HomeScreenState extends State<HomeScreen>
-    with SingleTickerProviderStateMixin {
-  final TextEditingController _messageController = TextEditingController();
-  final ScrollController _scrollController = ScrollController();
-  final List<ChatMessage> _messages = [];
-  bool _isListening = false;
-  int _selectedIndex = 0;
-  bool _isFabExpanded = false;
-  late AnimationController _fabController;
-  late Animation<double> _fabAnimation;
-
+class _HomeScreenState extends ConsumerState<HomeScreen> {
   List<Widget> _screens = [];
 
   @override
   void initState() {
     super.initState();
-    _fabController = AnimationController(
-      duration: const Duration(milliseconds: 300),
-      vsync: this,
-    );
-    _fabAnimation = CurvedAnimation(
-      parent: _fabController,
-      curve: Curves.easeOut,
-      reverseCurve: Curves.easeIn,
-    );
-
-    // Initialize screens
     _initializeScreens();
 
-    // Handle initial arguments if provided
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (widget.arguments != null) {
-        if (widget.arguments!.containsKey('screen') &&
-            widget.arguments!['screen'] is int) {
-          setState(() {
-            _selectedIndex = widget.arguments!['screen'];
-          });
-        }
-
-        // Handle initial message for chat screen
-        if (widget.arguments!.containsKey('initial_message') &&
-            widget.arguments!['initial_message'] is String &&
-            _selectedIndex == 3) {
-          // Update the chat screen with the initial message
-          setState(() {
-            _screens[3] = ChatScreen(arguments: {
-              'initial_message': widget.arguments!['initial_message']
-            });
-          });
-        }
-      }
+      _applyRouteArguments();
     });
   }
 
@@ -81,70 +40,43 @@ class _HomeScreenState extends State<HomeScreen>
     ];
   }
 
-  @override
-  void dispose() {
-    _messageController.dispose();
-    _scrollController.dispose();
-    _fabController.dispose();
-    super.dispose();
+  void _applyRouteArguments() {
+    final args = widget.arguments;
+    if (args == null) return;
+
+    if (args.containsKey('screen') && args['screen'] is int) {
+      ref.read(homeTabProvider.notifier).state =
+          HomeTab.fromIndex(args['screen'] as int);
+    }
+
+    if (args.containsKey('initial_message') &&
+        args['initial_message'] is String &&
+        ref.read(homeTabProvider) == HomeTab.chat) {
+      setState(() {
+        _screens[HomeTab.chat.index] = ChatScreen(arguments: {
+          'initial_message': args['initial_message'],
+        });
+      });
+    }
   }
 
-  void _sendMessage() {
-    if (_messageController.text.trim().isEmpty) return;
-
-    setState(() {
-      _messages.add(
-        ChatMessage(
-          text: _messageController.text,
-          isUser: true,
-          timestamp: DateTime.now(),
-        ),
-      );
-      _messageController.clear();
-    });
-
-    _scrollToBottom();
-    // TODO: Implement AI response
-  }
-
-  void _scrollToBottom() {
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (_scrollController.hasClients) {
-        _scrollController.animateTo(
-          _scrollController.position.maxScrollExtent,
-          duration: const Duration(milliseconds: 300),
-          curve: Curves.easeOut,
-        );
-      }
-    });
-  }
-
-  void _toggleListening() {
-    setState(() {
-      _isListening = !_isListening;
-    });
-    // TODO: Implement voice recognition
-  }
-
-  void _toggleFab() {
-    setState(() {
-      _isFabExpanded = !_isFabExpanded;
-      if (_isFabExpanded) {
-        _fabController.forward();
-      } else {
-        _fabController.reverse();
-      }
-    });
+  void _selectTab(int index) {
+    ref.read(homeTabProvider.notifier).state = HomeTab.fromIndex(index);
   }
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final selectedTab = ref.watch(homeTabProvider);
+
     return Scaffold(
-      body: IndexedStack(index: _selectedIndex, children: _screens),
+      body: IndexedStack(
+        index: selectedTab.index,
+        children: _screens,
+      ),
       bottomNavigationBar: BottomNavigationBar(
-        currentIndex: _selectedIndex,
-        onTap: (index) => setState(() => _selectedIndex = index),
+        currentIndex: selectedTab.index,
+        onTap: _selectTab,
         type: BottomNavigationBarType.fixed,
         selectedItemColor: theme.colorScheme.primary,
         unselectedItemColor: theme.colorScheme.onSurfaceVariant,
@@ -157,57 +89,20 @@ class _HomeScreenState extends State<HomeScreen>
             icon: Icon(Icons.calendar_today),
             label: 'Calendar',
           ),
-          BottomNavigationBarItem(icon: Icon(Icons.work), label: 'Workspace'),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.work),
+            label: 'Workspace',
+          ),
           BottomNavigationBarItem(
             icon: Icon(Icons.chat_bubble_outline),
             label: 'Chat',
           ),
-          BottomNavigationBarItem(icon: Icon(Icons.person), label: 'Profile'),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.person),
+            label: 'Profile',
+          ),
         ],
       ),
     );
   }
-}
-
-class _ChatBubble extends StatelessWidget {
-  final ChatMessage message;
-
-  const _ChatBubble({required this.message});
-
-  @override
-  Widget build(BuildContext context) {
-    return Align(
-      alignment: message.isUser ? Alignment.centerRight : Alignment.centerLeft,
-      child: Container(
-        margin: const EdgeInsets.symmetric(vertical: 4),
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
-        decoration: BoxDecoration(
-          color: message.isUser
-              ? Colors.green.shade400
-              : Theme.of(context).colorScheme.surfaceContainerHighest,
-          borderRadius: BorderRadius.circular(20),
-        ),
-        child: Text(
-          message.text,
-          style: TextStyle(
-            color: message.isUser
-                ? Colors.white
-                : Theme.of(context).colorScheme.onSurface,
-          ),
-        ),
-      ),
-    );
-  }
-}
-
-class ChatMessage {
-  final String text;
-  final bool isUser;
-  final DateTime timestamp;
-
-  ChatMessage({
-    required this.text,
-    required this.isUser,
-    required this.timestamp,
-  });
 }

--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
 import '../../providers/navigation/models/home_tab.dart';
 import '../../providers/navigation_provider.dart';
+import '../../router/app_routes.dart';
 import '../workspace/workspace_screen.dart';
 import '../calendar/calendar_screen.dart';
 import '../profile/profile_screen.dart';
@@ -9,70 +11,122 @@ import '../chat/chat_screen.dart';
 import 'dashboard_screen.dart';
 
 class HomeScreen extends ConsumerStatefulWidget {
+  final String location;
+  final Map<String, String> queryParameters;
   final Map<String, dynamic>? arguments;
 
-  const HomeScreen({super.key, this.arguments});
+  const HomeScreen({
+    super.key,
+    this.location = AppRoutes.home,
+    this.queryParameters = const {},
+    this.arguments,
+  });
 
   @override
   ConsumerState<HomeScreen> createState() => _HomeScreenState();
 }
 
 class _HomeScreenState extends ConsumerState<HomeScreen> {
-  List<Widget> _screens = [];
+  int _workspaceTabIndex = 0;
 
   @override
   void initState() {
     super.initState();
-    _initializeScreens();
-
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      _applyRouteArguments();
+      _syncFromRoute(widget.location);
+      _applyLegacyArguments();
     });
   }
 
-  void _initializeScreens() {
-    _screens = [
-      const DashboardScreen(),
-      const CalendarScreen(),
-      const WorkspaceScreen(),
-      const ChatScreen(),
-      const ProfileScreen(),
-    ];
+  @override
+  void didUpdateWidget(HomeScreen oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.location != widget.location ||
+        oldWidget.queryParameters != widget.queryParameters) {
+      _syncFromRoute(widget.location);
+    }
   }
 
-  void _applyRouteArguments() {
+  void _syncFromRoute(String location) {
+    final tab = AppRoutes.homeTabForPath(location);
+    if (ref.read(homeTabProvider) != tab) {
+      ref.read(homeTabProvider.notifier).state = tab;
+    }
+
+    final workspaceTab = AppRoutes.workspaceTabIndexForPath(location);
+    if (workspaceTab != null && _workspaceTabIndex != workspaceTab) {
+      setState(() => _workspaceTabIndex = workspaceTab);
+    }
+  }
+
+  void _applyLegacyArguments() {
     final args = widget.arguments;
     if (args == null) return;
 
     if (args.containsKey('screen') && args['screen'] is int) {
-      ref.read(homeTabProvider.notifier).state =
-          HomeTab.fromIndex(args['screen'] as int);
-    }
-
-    if (args.containsKey('initial_message') &&
-        args['initial_message'] is String &&
-        ref.read(homeTabProvider) == HomeTab.chat) {
-      setState(() {
-        _screens[HomeTab.chat.index] = ChatScreen(arguments: {
-          'initial_message': args['initial_message'],
-        });
-      });
+      final tab = HomeTab.fromIndex(args['screen'] as int);
+      ref.read(homeTabProvider.notifier).state = tab;
+      final path = AppRoutes.pathForHomeTab(tab);
+      if (widget.location != path) {
+        context.go(path);
+      }
     }
   }
 
   void _selectTab(int index) {
-    ref.read(homeTabProvider.notifier).state = HomeTab.fromIndex(index);
+    final tab = HomeTab.fromIndex(index);
+    ref.read(homeTabProvider.notifier).state = tab;
+
+    final path = AppRoutes.pathForHomeTab(tab);
+    if (widget.location != path) {
+      context.go(path);
+    }
+  }
+
+  void _onWorkspaceTabSelected(int index) {
+    if (_workspaceTabIndex != index) {
+      setState(() => _workspaceTabIndex = index);
+    }
+
+    final path = AppRoutes.pathForWorkspaceTabIndex(index);
+    if (widget.location != path) {
+      context.go(path);
+    }
+  }
+
+  Map<String, dynamic>? get _chatArguments {
+    final message = widget.queryParameters['message'];
+    if (message == null || message.isEmpty) {
+      return null;
+    }
+    return {'initial_message': message};
   }
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final selectedTab = ref.watch(homeTabProvider);
+    final chatMessage = widget.queryParameters['message'];
+
+    final screens = <Widget>[
+      const DashboardScreen(),
+      const CalendarScreen(),
+      WorkspaceScreen(
+        key: ValueKey<int>(_workspaceTabIndex),
+        initialTabIndex: _workspaceTabIndex,
+        onTabSelected: _onWorkspaceTabSelected,
+      ),
+      ChatScreen(
+        key: ValueKey<String?>(chatMessage),
+        arguments: _chatArguments,
+      ),
+      const ProfileScreen(),
+    ];
 
     return Scaffold(
       body: IndexedStack(
         index: selectedTab.index,
-        children: _screens,
+        children: screens,
       ),
       bottomNavigationBar: BottomNavigationBar(
         currentIndex: selectedTab.index,

--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 import '../../providers/navigation/models/home_tab.dart';
-import '../../providers/navigation_provider.dart';
 import '../../router/app_routes.dart';
 import '../workspace/workspace_screen.dart';
 import '../calendar/calendar_screen.dart';
@@ -10,84 +8,34 @@ import '../profile/profile_screen.dart';
 import '../chat/chat_screen.dart';
 import 'dashboard_screen.dart';
 
-class HomeScreen extends ConsumerStatefulWidget {
+class HomeScreen extends StatefulWidget {
   final String location;
   final Map<String, String> queryParameters;
-  final Map<String, dynamic>? arguments;
 
   const HomeScreen({
     super.key,
     this.location = AppRoutes.home,
     this.queryParameters = const {},
-    this.arguments,
   });
 
   @override
-  ConsumerState<HomeScreen> createState() => _HomeScreenState();
+  State<HomeScreen> createState() => _HomeScreenState();
 }
 
-class _HomeScreenState extends ConsumerState<HomeScreen> {
-  int _workspaceTabIndex = 0;
+class _HomeScreenState extends State<HomeScreen> {
+  HomeTab get _selectedTab => AppRoutes.homeTabForPath(widget.location);
 
-  @override
-  void initState() {
-    super.initState();
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      _syncFromRoute(widget.location);
-      _applyLegacyArguments();
-    });
-  }
-
-  @override
-  void didUpdateWidget(HomeScreen oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (oldWidget.location != widget.location ||
-        oldWidget.queryParameters != widget.queryParameters) {
-      _syncFromRoute(widget.location);
-    }
-  }
-
-  void _syncFromRoute(String location) {
-    final tab = AppRoutes.homeTabForPath(location);
-    if (ref.read(homeTabProvider) != tab) {
-      ref.read(homeTabProvider.notifier).state = tab;
-    }
-
-    final workspaceTab = AppRoutes.workspaceTabIndexForPath(location);
-    if (workspaceTab != null && _workspaceTabIndex != workspaceTab) {
-      setState(() => _workspaceTabIndex = workspaceTab);
-    }
-  }
-
-  void _applyLegacyArguments() {
-    final args = widget.arguments;
-    if (args == null) return;
-
-    if (args.containsKey('screen') && args['screen'] is int) {
-      final tab = HomeTab.fromIndex(args['screen'] as int);
-      ref.read(homeTabProvider.notifier).state = tab;
-      final path = AppRoutes.pathForHomeTab(tab);
-      if (widget.location != path) {
-        context.go(path);
-      }
-    }
-  }
+  int get _workspaceTabIndex =>
+      AppRoutes.workspaceTabIndexForPath(widget.location) ?? 0;
 
   void _selectTab(int index) {
-    final tab = HomeTab.fromIndex(index);
-    ref.read(homeTabProvider.notifier).state = tab;
-
-    final path = AppRoutes.pathForHomeTab(tab);
+    final path = AppRoutes.pathForHomeTab(HomeTab.fromIndex(index));
     if (widget.location != path) {
       context.go(path);
     }
   }
 
   void _onWorkspaceTabSelected(int index) {
-    if (_workspaceTabIndex != index) {
-      setState(() => _workspaceTabIndex = index);
-    }
-
     final path = AppRoutes.pathForWorkspaceTabIndex(index);
     if (widget.location != path) {
       context.go(path);
@@ -105,7 +53,7 @@ class _HomeScreenState extends ConsumerState<HomeScreen> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final selectedTab = ref.watch(homeTabProvider);
+    final selectedTab = _selectedTab;
     final chatMessage = widget.queryParameters['message'];
 
     final screens = <Widget>[

--- a/lib/screens/splash_screen.dart
+++ b/lib/screens/splash_screen.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'onboarding/onboarding_screen.dart';
 import '../services/navigation_service.dart';
 import '../services/supabase_service.dart';
-import 'home/home_screen.dart';
 import 'auth/login_screen.dart';
 
 class SplashScreen extends StatefulWidget {
@@ -51,17 +50,9 @@ class _SplashScreenState extends State<SplashScreen>
 
       if (currentUser != null) {
         if (args != null && args is Map<String, dynamic>) {
-          Navigator.of(context).pushReplacement(
-            MaterialPageRoute(
-              builder: (context) => HomeScreen(arguments: args),
-            ),
-          );
+          NavigationService().goHome(arguments: args);
         } else {
-          Navigator.of(context).pushReplacement(
-            MaterialPageRoute(
-              builder: (context) => const HomeScreen(),
-            ),
-          );
+          NavigationService().goHome();
         }
       } else {
         Navigator.of(context).pushReplacement(

--- a/lib/screens/workspace/workspace_screen.dart
+++ b/lib/screens/workspace/workspace_screen.dart
@@ -10,7 +10,14 @@ import '../../services/supabase_service.dart';
 import '../../widgets/custom_widgets.dart';
 
 class WorkspaceScreen extends StatefulWidget {
-  const WorkspaceScreen({super.key});
+  final int initialTabIndex;
+  final ValueChanged<int>? onTabSelected;
+
+  const WorkspaceScreen({
+    super.key,
+    this.initialTabIndex = 0,
+    this.onTabSelected,
+  });
 
   @override
   State<WorkspaceScreen> createState() => _WorkspaceScreenState();
@@ -27,7 +34,11 @@ class _WorkspaceScreenState extends State<WorkspaceScreen>
   @override
   void initState() {
     super.initState();
-    _tabController = TabController(length: 3, vsync: this);
+    _tabController = TabController(
+      length: 3,
+      vsync: this,
+      initialIndex: widget.initialTabIndex.clamp(0, 2),
+    );
     _tabController.addListener(_handleTabChange);
 
     // Simulate loading delay
@@ -47,10 +58,22 @@ class _WorkspaceScreenState extends State<WorkspaceScreen>
     super.dispose();
   }
 
+  @override
+  void didUpdateWidget(WorkspaceScreen oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.initialTabIndex != widget.initialTabIndex &&
+        _tabController.index != widget.initialTabIndex) {
+      _tabController.animateTo(widget.initialTabIndex.clamp(0, 2));
+    }
+  }
+
   void _handleTabChange() {
     if (_tabController.indexIsChanging) {
       setState(() {});
+      return;
     }
+
+    widget.onTabSelected?.call(_tabController.index);
   }
 
   void _showCreateDialog() {

--- a/lib/services/navigation_service.dart
+++ b/lib/services/navigation_service.dart
@@ -1,4 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+import '../providers/navigation/models/home_tab.dart';
+import '../router/app_routes.dart';
+import '../screens/home/home_screen.dart';
 
 class NavigationService {
   static final NavigationService _instance = NavigationService._internal();
@@ -6,6 +11,49 @@ class NavigationService {
   NavigationService._internal();
 
   final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
+  GoRouter? _router;
+
+  void setRouter(GoRouter router) {
+    _router = router;
+  }
+
+  GoRouter get router {
+    final router = _router;
+    if (router == null) {
+      throw StateError('GoRouter has not been initialized');
+    }
+    return router;
+  }
+
+  /// Navigates to the authenticated home shell, preserving legacy route args.
+  void goHome({Map<String, dynamic>? arguments}) {
+    if (arguments != null) {
+      if (arguments.containsKey('screen') && arguments['screen'] is int) {
+        final tab = AppRoutes.homeTabForScreenIndex(arguments['screen'] as int);
+        if (arguments.containsKey('initial_message') &&
+            arguments['initial_message'] is String &&
+            tab == HomeTab.chat) {
+          router.go(
+            '${AppRoutes.chat}?message=${Uri.encodeComponent(arguments['initial_message'] as String)}',
+          );
+          return;
+        }
+
+        router.go(AppRoutes.pathForHomeTab(tab));
+        return;
+      }
+
+      if (arguments.containsKey('initial_message') &&
+          arguments['initial_message'] is String) {
+        router.go(
+          '${AppRoutes.chat}?message=${Uri.encodeComponent(arguments['initial_message'] as String)}',
+        );
+        return;
+      }
+    }
+
+    router.go(AppRoutes.home);
+  }
 
   Future<dynamic> navigateTo(Widget screen) {
     final navigator = navigatorKey.currentState;
@@ -13,21 +61,32 @@ class NavigationService {
       throw StateError('Navigator not initialized');
     }
     return navigator.push(
-      MaterialPageRoute(builder: (_) => screen),
+      MaterialPageRoute<void>(builder: (_) => screen),
     );
   }
 
   Future<dynamic> navigateToReplacement(Widget screen) {
+    if (screen is HomeScreen) {
+      goHome(arguments: screen.arguments);
+      return Future<void>.value();
+    }
+
     final navigator = navigatorKey.currentState;
     if (navigator == null) {
       throw StateError('Navigator not initialized');
     }
     return navigator.pushReplacement(
-      MaterialPageRoute(builder: (_) => screen),
+      MaterialPageRoute<void>(builder: (_) => screen),
     );
   }
 
   void goBack() {
+    final router = _router;
+    if (router != null && router.canPop()) {
+      router.pop();
+      return;
+    }
+
     final navigator = navigatorKey.currentState;
     if (navigator == null) {
       throw StateError('Navigator not initialized');

--- a/lib/services/navigation_service.dart
+++ b/lib/services/navigation_service.dart
@@ -67,7 +67,7 @@ class NavigationService {
 
   Future<dynamic> navigateToReplacement(Widget screen) {
     if (screen is HomeScreen) {
-      goHome(arguments: screen.arguments);
+      goHome();
       return Future<void>.value();
     }
 

--- a/lib/utils/url_strategy.dart
+++ b/lib/utils/url_strategy.dart
@@ -1,0 +1,2 @@
+export 'url_strategy_stub.dart'
+    if (dart.library.html) 'url_strategy_web.dart';

--- a/lib/utils/url_strategy_stub.dart
+++ b/lib/utils/url_strategy_stub.dart
@@ -1,0 +1,2 @@
+/// Configures path-based URLs on web; no-op on other platforms.
+void configureAppUrlStrategy() {}

--- a/lib/utils/url_strategy_web.dart
+++ b/lib/utils/url_strategy_web.dart
@@ -1,0 +1,6 @@
+import 'package:flutter_web_plugins/flutter_web_plugins.dart';
+
+/// Configures path-based URLs on web; no-op on other platforms.
+void configureAppUrlStrategy() {
+  usePathUrlStrategy();
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,6 +45,7 @@ dependencies:
   flutter_riverpod: ^2.6.1
   riverpod_annotation: ^2.6.1
   freezed_annotation: ^2.4.4
+  go_router: ^14.8.1
 
   # Local storage
   shared_preferences: ^2.5.3

--- a/test/router/app_routes_test.dart
+++ b/test/router/app_routes_test.dart
@@ -1,0 +1,29 @@
+import 'package:ell_ena/providers/navigation/models/home_tab.dart';
+import 'package:ell_ena/router/app_routes.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('AppRoutes', () {
+    test('maps home tab paths bidirectionally', () {
+      for (final tab in HomeTab.values) {
+        final path = AppRoutes.pathForHomeTab(tab);
+        expect(AppRoutes.homeTabForPath(path), tab);
+      }
+    });
+
+    test('maps workspace deep links to workspace tab', () {
+      expect(AppRoutes.homeTabForPath(AppRoutes.tasks), HomeTab.workspace);
+      expect(AppRoutes.homeTabForPath(AppRoutes.tickets), HomeTab.workspace);
+      expect(AppRoutes.homeTabForPath(AppRoutes.meetings), HomeTab.workspace);
+      expect(AppRoutes.workspaceTabIndexForPath(AppRoutes.tasks), 0);
+      expect(AppRoutes.workspaceTabIndexForPath(AppRoutes.tickets), 1);
+      expect(AppRoutes.workspaceTabIndexForPath(AppRoutes.meetings), 2);
+    });
+
+    test('maps workspace tab indexes to paths', () {
+      expect(AppRoutes.pathForWorkspaceTabIndex(0), AppRoutes.tasks);
+      expect(AppRoutes.pathForWorkspaceTabIndex(1), AppRoutes.tickets);
+      expect(AppRoutes.pathForWorkspaceTabIndex(2), AppRoutes.meetings);
+    });
+  });
+}


### PR DESCRIPTION
## Description

This PR integrates `go_router` to provide URL-based navigation, browser history support, and deep linking for Ell-ena while preserving the existing mobile navigation experience and screen architecture.

The implementation builds on the previously introduced Riverpod navigation foundation and responsive web layout work, enabling navigation state to be reflected in shareable URLs without introducing duplicate screens or platform-specific navigation flows.

## Screen Recording


https://github.com/user-attachments/assets/0bddf5cf-f3ab-4afb-b842-16bac05f3f86


## Changes Made

### Routing Infrastructure

* Added `go_router` as the application's routing solution
* Introduced centralized route definitions through `AppRoutes`
* Configured route handling using a shell-based routing structure
* Migrated `MaterialApp` to use router-based navigation

### URL-Based Navigation

Added support for direct navigation to:

* `/home`
* `/calendar`
* `/workspace`
* `/tasks`
* `/tickets`
* `/meetings`
* `/chat`
* `/profile`

Users can now access major application sections directly through URLs.

### Browser History Support

* Browser back button navigation
* Browser forward button navigation
* Refresh-safe routing
* Shareable URLs for application sections

### Deep Linking

Deep links now open the appropriate application view:

* `/tasks` → Workspace → Tasks
* `/tickets` → Workspace → Tickets
* `/meetings` → Workspace → Meetings
* `/chat` → Chat
* `/profile` → Profile

### Navigation State

- Navigation state is now derived directly from the current route
- Eliminated redundant navigation state synchronization
- Preserved the existing IndexedStack-based screen architecture
- Maintained consistent navigation behavior across both mobile and web platforms

### Workspace Navigation

Workspace sub-sections now support direct URL access:

* Tasks
* Tickets
* Meetings

Navigation between workspace tabs updates the URL accordingly.

## Architecture Decisions

* Reused all existing screens
* Preserved the current `HomeScreen` + `IndexedStack` architecture
* Avoided introducing web-specific screen variants
* Kept mobile navigation behavior unchanged
* Built routing around go_router as the single source of truth for navigation state while preserving the existing HomeScreen and IndexedStack architecture.


### ✅ Checklist

- [x] I have read the contributing guidelines.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if applicable).
- [x] Any dependent changes have been merged and published in downstream modules.

