### PR TITLE
docs: normalize heading hierarchy in system components section

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,25 +83,25 @@ Ell-ena uses PostgreSQL (via Supabase) with strict Row-Level Security (RLS) and 
 
 ## ✨ System Components
 
-#### 1. Frontend Layer (Flutter)
+### 1. Frontend Layer (Flutter)
 - **Auth Module**: Handles user authentication, team management, and role-based access control
 - **Task Manager**: Processes task creation, updates, and workflow management
 - **Meeting Manager**: Manages meeting scheduling, transcription, and contextual analysis
 - **Chat Interface**: Provides natural language interaction with the AI assistant
 
-#### 2. Supabase Service Layer
+### 2. Supabase Service Layer
 - **Auth Client**: Manages authentication tokens and session state
 - **Data Client**: Handles real-time data synchronization with PostgreSQL
 - **Storage Client**: Manages file uploads and retrieval
 - **RPC Client**: Executes remote procedure calls to Edge Functions
 
-#### 3. Backend Layer (Supabase)
+### 3. Backend Layer (Supabase)
 - **Authentication**: Handles user identity, security, and session management
 - **PostgreSQL DB**: Stores structured data with Row-Level Security policies
 - **Object Storage**: Manages binary assets like audio recordings and documents
 - **Edge Functions**: Executes serverless functions for business logic
 
-#### 4. AI Processing Pipeline
+### 4. AI Processing Pipeline
 - **NLU Processor**: Processes natural language using Gemini API
 - **Vector Database**: Stores and retrieves semantic embeddings for context-aware searches
 - **Embedding Generator**: Creates vector embeddings from text for semantic similarity


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #None

## 📝 Description
This PR fixes a markdown formatting issue in the System Components section of the README. The layer subsections were incorrectly using `H4` (`####`) headings directly under an `H2` (`##`), which broke the document's heading hierarchy. I normalized these to `H3` (`###`) headings to ensure proper markdown structure and rendering.

## 🔧 Changes Made
- Changed `####` to `###` for the four architectural layer subsections (Frontend Layer, Supabase Service Layer, Backend Layer, AI Processing Pipeline) under the `## ✨ System Components` heading.

## 📷 Screenshots or Visual Changes (if applicable)
N/A

## 🤝 Collaboration
Collaborated with: N/A

### ✅ Checklist
- [x] I have read the contributing guidelines.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if applicable).
- [ ] Any dependent changes have been merged and published in downstream modules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the “System Components” section formatting for improved readability and consistency.
  * Standardized subsection headings and bullet styling across the frontend, service layer, backend, and AI processing sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->