### PR TITLE
docs: fix placeholder clone URL to point to the actual repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,8 +144,8 @@ Ell-ena uses PostgreSQL (via Supabase) with strict Row-Level Security (RLS) and 
 
 1. Clone the repository
    ```bash
-   git clone https://github.com/yourusername/Ell-ena.git
-   cd Ell-ena
+  git clone https://github.com/AOSSIE-Org/Ell-ena.git
+  cd Ell-ena
    ```
 
 2. Set up backend (Supabase)


### PR DESCRIPTION
Closes #None (just a documentation quick fix )

## 📝 Description
Fixed the "Getting Started" clone instructions in README.md — the `git clone` command used a placeholder URL (`yourusername/Ell-ena`) instead of the actual repository path.

## 🔧 Changes Made
- Updated the clone URL from `https://github.com/yourusername/Ell-ena.git` to `https://github.com/AOSSIE-Org/Ell-ena.git`

## 📷 Screenshots or Visual Changes (if applicable)
N/A — documentation-only fix.

## 🤝 Collaboration
Collaborated with: none

### ✅ Checklist
- [x] I have read the contributing guidelines.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if applicable).
- [x] Any dependent changes have been merged and published in downstream modules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions with the official repository URL.
  * Replaced the placeholder repository address in the setup guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->