### PR TITLE
Improving readme with discord link and logo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,12 @@
 
 This guide explains how to set up Ell-ena locally (frontend + Supabase backend) and how to contribute via pull requests.
 
+## Community
+
+Discuss Ell-ena on the AOSSIE Discord in our project channel:
+
+- [Ell-ena Discord channel](https://discord.com/channels/1022871757289422898/1349032611267477586)
+
 ## Quick start (most people follow this)
    Fork the repository https://github.com/AOSSIE-Org/Ell-ena
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Ell-ena
 
+<p align="center">
+  <img src="ELL-ena-logo/svg/ell-ena%20black.svg" alt="Ell-ena logo" width="180"/>
+</p>
 
 **Ell-ena** is your AI-powered teammate that makes managing work effortless. From automatically creating tickets to capturing every detail in meeting transcriptions, Ell-ena keeps the full context of your projects at its fingertips—so nothing ever falls through the cracks.  
 
@@ -241,6 +244,12 @@ Ell-ena is an open-source project under AOSSIE for GSoC'25. We welcome contribut
 5. Open a Pull Request
 
 Please read our [Contributing Guidelines](CONTRIBUTING.md) for more details.
+
+## 💬 Community
+
+Join the AOSSIE Discord and discuss Ell-ena in our project channel:
+
+- [Ell-ena Discord channel](https://discord.com/channels/1022871757289422898/1349032611267477586)
 
 ## 📚 Documentation
 


### PR DESCRIPTION
## Summary

Improves Ell-ena's repository contribution documentation.

### Changes

* Updated README to use the official Ell-ena logo.
* Updated `CONTRIBUTING.md` with the specific Ell-ena Discord channel link.

No application functionality changes.


## 🤝 Collaboration

<!-- If you collaborated with someone on this pull request, mention their GitHub username or name here. -->
Collaborated with: `@username` (optional)


### ✅ Checklist

- [x] I have read the contributing guidelines.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if applicable).
- [x] Any dependent changes have been merged and published in downstream modules.

