### PR TITLE
Feature/profile avatar upload

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,6 +9,7 @@ import 'services/navigation_service.dart';
 import 'services/supabase_service.dart';
 import 'services/ai_service.dart';
 import 'providers/theme_provider.dart';
+import 'providers/user_profile_provider.dart';
 import 'theme/theme_controller.dart';
 import 'theme/app_themes.dart';
 
@@ -21,17 +22,28 @@ void main() async {
   } catch (e) {
     debugPrint('Error initializing services: $e');
   }
-  
+
   final themeController = await ThemeController.create();
+  final userProfileController = UserProfileController();
 
 runApp(
   WidgetsBindingObserverWidget(
     child: ProviderScope(
       overrides: [
         themeControllerProvider.overrideWith((ref) => themeController),
+        userProfileControllerProvider.overrideWith(
+          (ref) => userProfileController,
+        ),
       ],
-      child: ChangeNotifierProvider<ThemeController>.value(
-        value: themeController,
+      child: MultiProvider(
+        providers: [
+          ChangeNotifierProvider<ThemeController>.value(
+            value: themeController,
+          ),
+          ChangeNotifierProvider<UserProfileController>.value(
+            value: userProfileController,
+          ),
+        ],
         child: const MyApp(),
       ),
     ),

--- a/lib/providers/user_profile_provider.dart
+++ b/lib/providers/user_profile_provider.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../services/supabase_service.dart';
+
+/// Holds the current user's profile (id, full_name, email, avatar_url,
+/// role, team_id) as shared, reactive app state, so every screen holding a
+/// reference to this controller re-renders when the profile changes --
+/// instead of each screen independently calling
+/// SupabaseService().getCurrentUserProfile() into its own local state.
+class UserProfileController extends ChangeNotifier {
+  Map<String, dynamic>? _profile;
+
+  Map<String, dynamic>? get profile => _profile;
+
+  bool get isLoaded => _profile != null;
+
+  String? get id => _profile?['id'] as String?;
+  String? get fullName => _profile?['full_name'] as String?;
+  String? get email => _profile?['email'] as String?;
+  String? get avatarUrl => _profile?['avatar_url'] as String?;
+  String? get role => _profile?['role'] as String?;
+  String? get teamId => _profile?['team_id'] as String?;
+
+  /// Loads/refreshes the profile from [SupabaseService] and notifies
+  /// listeners. Pass [forceRefresh] to bypass SupabaseService's own cache.
+  Future<void> refresh({bool forceRefresh = false}) async {
+    final profile = await SupabaseService()
+        .getCurrentUserProfile(forceRefresh: forceRefresh);
+    _profile = profile;
+    notifyListeners();
+  }
+
+  /// Updates just the local avatar_url and notifies listeners, without a
+  /// full profile refetch. Call this right after a successful
+  /// uploadAvatar()/removeAvatar() call on SupabaseService, so every screen
+  /// holding a reference to this provider re-renders immediately.
+  void updateAvatarUrl(String? newUrl) {
+    _profile = {...?_profile, 'avatar_url': newUrl};
+    notifyListeners();
+  }
+}
+
+/// Riverpod exposure of [UserProfileController].
+/// Overridden at app startup with the instance created in main.dart.
+final userProfileControllerProvider =
+    ChangeNotifierProvider<UserProfileController>((ref) {
+  throw StateError(
+    'userProfileControllerProvider must be overridden in ProviderScope',
+  );
+});

--- a/lib/screens/chat/chat_screen.dart
+++ b/lib/screens/chat/chat_screen.dart
@@ -290,7 +290,6 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
           text: userMessage,
           isUser: true,
           timestamp: DateTime.now(),
-          avatarUrl: context.read<UserProfileController>().avatarUrl,
         ),
       );
       _isProcessing = true;
@@ -1417,8 +1416,7 @@ class _ChatBubble extends StatelessWidget {
             ),
           ),
           const SizedBox(width: 8),
-          if (message.isUser)
-            _buildAvatar(context, isUser: true, avatarUrl: message.avatarUrl),
+          if (message.isUser) _buildAvatar(context, isUser: true),
         ],
       ),
     );
@@ -1560,10 +1558,18 @@ class _ChatBubble extends StatelessWidget {
   Widget _buildAvatar(
     BuildContext context, {
     required bool isUser,
-    String? avatarUrl,
   }) {
-    if (isUser && avatarUrl != null && avatarUrl.isNotEmpty) {
-      return UserAvatar(avatarUrl: avatarUrl, name: 'You', radius: 18);
+    if (isUser) {
+      // context.select (not context.watch) so this bubble only rebuilds
+      // when avatarUrl specifically changes, not on every profile field
+      // change -- and reads it live, so old messages in the chat history
+      // pick up a new avatar immediately after it's changed, instead of
+      // showing whatever was current at send-time.
+      final avatarUrl = context
+          .select<UserProfileController, String?>((c) => c.avatarUrl);
+      if (avatarUrl != null && avatarUrl.isNotEmpty) {
+        return UserAvatar(avatarUrl: avatarUrl, name: 'You', radius: 18);
+      }
     }
 
     final colorScheme = Theme.of(context).colorScheme;
@@ -1737,7 +1743,6 @@ class ChatMessage {
   final bool isCard;
   final String? cardType;
   final Map<String, dynamic>? cardData;
-  final String? avatarUrl; // Add avatar URL for profile pictures
 
   ChatMessage({
     required this.text,
@@ -1746,7 +1751,6 @@ class ChatMessage {
     this.isCard = false,
     this.cardType,
     this.cardData,
-    this.avatarUrl,
   });
 }
 

--- a/lib/screens/chat/chat_screen.dart
+++ b/lib/screens/chat/chat_screen.dart
@@ -1,8 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import 'package:ell_ena/services/ai_service.dart';
 import 'package:ell_ena/services/supabase_service.dart';
 import 'package:intl/intl.dart';
 import 'package:loading_animation_widget/loading_animation_widget.dart';
+import '../../providers/user_profile_provider.dart';
+import '../../widgets/custom_widgets.dart';
 import '../tasks/task_detail_screen.dart';
 import '../tickets/ticket_detail_screen.dart';
 import '../meetings/meeting_detail_screen.dart';
@@ -283,7 +286,12 @@ class _ChatScreenState extends State<ChatScreen> with TickerProviderStateMixin {
 
     setState(() {
       _messages.add(
-        ChatMessage(text: userMessage, isUser: true, timestamp: DateTime.now()),
+        ChatMessage(
+          text: userMessage,
+          isUser: true,
+          timestamp: DateTime.now(),
+          avatarUrl: context.read<UserProfileController>().avatarUrl,
+        ),
       );
       _isProcessing = true;
     });
@@ -1409,7 +1417,8 @@ class _ChatBubble extends StatelessWidget {
             ),
           ),
           const SizedBox(width: 8),
-          if (message.isUser) _buildAvatar(context, isUser: true),
+          if (message.isUser)
+            _buildAvatar(context, isUser: true, avatarUrl: message.avatarUrl),
         ],
       ),
     );
@@ -1548,7 +1557,15 @@ class _ChatBubble extends StatelessWidget {
     );
   }
 
-  Widget _buildAvatar(BuildContext context, {required bool isUser}) {
+  Widget _buildAvatar(
+    BuildContext context, {
+    required bool isUser,
+    String? avatarUrl,
+  }) {
+    if (isUser && avatarUrl != null && avatarUrl.isNotEmpty) {
+      return UserAvatar(avatarUrl: avatarUrl, name: 'You', radius: 18);
+    }
+
     final colorScheme = Theme.of(context).colorScheme;
     return Container(
       width: 36,

--- a/lib/screens/home/dashboard_screen.dart
+++ b/lib/screens/home/dashboard_screen.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import '../../widgets/custom_widgets.dart';
 import 'package:fl_chart/fl_chart.dart';
 import 'package:intl/intl.dart';
+import '../../providers/user_profile_provider.dart';
 import '../../services/supabase_service.dart';
 import '../tasks/task_detail_screen.dart';
 import '../tickets/ticket_detail_screen.dart';
@@ -181,15 +183,20 @@ class _DashboardScreenState extends State<DashboardScreen>
 
       final supa = SupabaseService();
 
-      // Get user profile with team information
-      final profile = await supa.getCurrentUserProfile(forceRefresh: true);
+      // Get the current user's profile (avatar/name/team) from the shared
+      // controller -- forced, so a just-completed team switch is reflected
+      // immediately -- instead of an independent fetch, so this stays in
+      // sync with any other screen that updates it (e.g. Edit Profile).
+      final profileController = context.read<UserProfileController>();
+      await profileController.refresh(forceRefresh: true);
+      final profile = profileController.profile;
 
       // Set username
-      _userName = (profile?['full_name'] as String?)?.trim();
+      _userName = profileController.fullName?.trim();
 
       // Set current team
       if (profile != null && profile['team_id'] != null) {
-        _currentTeamId = profile['team_id'];
+        _currentTeamId = profileController.teamId;
         _currentTeamName = profile['teams']?['name'] ?? 'My Team';
       }
 
@@ -382,6 +389,10 @@ class _DashboardScreenState extends State<DashboardScreen>
         body: DashboardLoadingSkeleton(),
       );
     }
+    // Reactive: rebuilds when the shared avatar/name changes elsewhere
+    // (e.g. after an avatar upload on Edit Profile).
+    final avatarUrl = context.watch<UserProfileController>().avatarUrl;
+
     return Scaffold(
       backgroundColor: Theme.of(context).scaffoldBackgroundColor,
       body: RefreshIndicator(
@@ -442,10 +453,10 @@ class _DashboardScreenState extends State<DashboardScreen>
                                       width: 2,
                                     ),
                                   ),
-                                  child: const Icon(
-                                    Icons.person,
-                                    color: Colors.white,
-                                    size: 28,
+                                  child: UserAvatar(
+                                    avatarUrl: avatarUrl,
+                                    name: _userName ?? '?',
+                                    radius: 24,
                                   ),
                                 ),
                                 const SizedBox(width: 16),

--- a/lib/screens/home/home_screen.dart
+++ b/lib/screens/home/home_screen.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:provider/provider.dart';
 import '../../widgets/custom_widgets.dart';
+import '../../providers/user_profile_provider.dart';
 import '../../services/navigation_service.dart';
 import '../workspace/workspace_screen.dart';
 import '../calendar/calendar_screen.dart';
@@ -45,6 +47,16 @@ class _HomeScreenState extends State<HomeScreen>
 
     // Initialize screens
     _initializeScreens();
+
+    // Load the current user's profile (avatar, name, role, team) into the
+    // shared controller. This is the single convergence point for every
+    // "user is now entering the authenticated app" path -- splash screen
+    // (existing session), and login/signup/OTP-verify/team-selection all
+    // navigate here directly, bypassing splash. Fire-and-forget: every
+    // screen that reads this reactively via context.watch<UserProfileController>()
+    // rebuilds automatically once this completes, so nothing needs to
+    // block on it here.
+    context.read<UserProfileController>().refresh();
 
     // Handle initial arguments if provided
     WidgetsBinding.instance.addPostFrameCallback((_) {

--- a/lib/screens/profile/edit_profile_screen.dart
+++ b/lib/screens/profile/edit_profile_screen.dart
@@ -6,6 +6,7 @@ import 'package:provider/provider.dart';
 
 import '../../providers/user_profile_provider.dart';
 import '../../services/supabase_service.dart';
+import '../../widgets/custom_widgets.dart';
 
 class EditProfileScreen extends StatefulWidget {
   final Map<String, dynamic> userProfile;
@@ -373,93 +374,6 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
     }
   }
 
-  // Deterministic color per user, matching the pattern already used for
-  // initials avatars in team_members_screen.dart.
-  Color _avatarColorFor(String seed) {
-    const colors = [
-      Colors.blue,
-      Colors.green,
-      Colors.orange,
-      Colors.purple,
-      Colors.red,
-      Colors.teal,
-      Colors.indigo,
-      Colors.pink,
-    ];
-    return colors[seed.hashCode.abs() % colors.length];
-  }
-
-  String _initialsFor(String? name) {
-    final trimmed = name?.trim() ?? '';
-    if (trimmed.isEmpty) return '?';
-    final parts = trimmed.split(RegExp(r'\s+'));
-    final first = parts.first.isNotEmpty ? parts.first[0] : '';
-    final last =
-        parts.length > 1 && parts.last.isNotEmpty ? parts.last[0] : '';
-    final initials = (first + last).toUpperCase();
-    return initials.isEmpty ? '?' : initials;
-  }
-
-  Widget _buildAvatar() {
-    final displayName = _fullName ?? widget.userProfile['full_name'];
-    final seed = (displayName ?? _email ?? widget.userProfile['id'] ?? '?')
-        .toString();
-
-    if (_avatarUrl != null && _avatarUrl!.isNotEmpty) {
-      return ClipOval(
-        child: Image.network(
-          _avatarUrl!,
-          width: 100,
-          height: 100,
-          fit: BoxFit.cover,
-          loadingBuilder: (context, child, progress) {
-            if (progress == null) return child;
-            return Container(
-              width: 100,
-              height: 100,
-              color: Theme.of(context).colorScheme.surfaceVariant,
-              child: const Center(
-                child: CircularProgressIndicator(strokeWidth: 2),
-              ),
-            );
-          },
-          errorBuilder: (context, error, stackTrace) => Container(
-            width: 100,
-            height: 100,
-            color: _avatarColorFor(seed),
-            alignment: Alignment.center,
-            child: Text(
-              _initialsFor(displayName),
-              style: const TextStyle(
-                color: Colors.white,
-                fontSize: 32,
-                fontWeight: FontWeight.bold,
-              ),
-            ),
-          ),
-        ),
-      );
-    }
-
-    return Container(
-      width: 100,
-      height: 100,
-      decoration: BoxDecoration(
-        shape: BoxShape.circle,
-        color: _avatarColorFor(seed),
-      ),
-      alignment: Alignment.center,
-      child: Text(
-        _initialsFor(displayName),
-        style: const TextStyle(
-          color: Colors.white,
-          fontSize: 32,
-          fontWeight: FontWeight.bold,
-        ),
-      ),
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -517,7 +431,16 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
                                     ),
                                   ],
                                 ),
-                                child: _buildAvatar(),
+                                child: UserAvatar(
+                                  avatarUrl: _avatarUrl,
+                                  name: (_fullName ??
+                                          widget.userProfile['full_name'] ??
+                                          _email ??
+                                          widget.userProfile['id'] ??
+                                          '?')
+                                      .toString(),
+                                  radius: 50,
+                                ),
                               ),
                               InkWell(
                                 onTap: _isAvatarUpdating

--- a/lib/screens/profile/edit_profile_screen.dart
+++ b/lib/screens/profile/edit_profile_screen.dart
@@ -1,4 +1,10 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:provider/provider.dart';
+
+import '../../providers/user_profile_provider.dart';
 import '../../services/supabase_service.dart';
 
 class EditProfileScreen extends StatefulWidget {
@@ -18,7 +24,9 @@ class EditProfileScreen extends StatefulWidget {
 class _EditProfileScreenState extends State<EditProfileScreen> {
   final _formKey = GlobalKey<FormState>();
   final _supabaseService = SupabaseService();
+  final _imagePicker = ImagePicker();
   bool _isLoading = false;
+  bool _isAvatarUpdating = false;
 
   late final TextEditingController _firstNameController;
   late final TextEditingController _lastNameController;
@@ -26,6 +34,7 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
 
   String? _fullName;
   String? _email;
+  String? _avatarUrl;
 
   @override
   void initState() {
@@ -43,6 +52,7 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
 
     _fullName = widget.userProfile['full_name'];
     _email = widget.userProfile['email'];
+    _avatarUrl = widget.userProfile['avatar_url'] as String?;
   }
 
   @override
@@ -118,6 +128,338 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
     }
   }
 
+  Future<void> _showImageSourceActionSheet() async {
+    if (_isAvatarUpdating) return;
+
+    final source = await showModalBottomSheet<ImageSource>(
+      context: context,
+      backgroundColor: Theme.of(context).colorScheme.surface,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+      ),
+      builder: (context) {
+        return SafeArea(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              ListTile(
+                leading: const Icon(Icons.photo_library_outlined),
+                title: const Text('Choose from Gallery'),
+                onTap: () => Navigator.pop(context, ImageSource.gallery),
+              ),
+              ListTile(
+                leading: const Icon(Icons.camera_alt_outlined),
+                title: const Text('Take a Photo'),
+                onTap: () => Navigator.pop(context, ImageSource.camera),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+
+    if (source == null) return;
+    await _pickAndPreviewImage(source);
+  }
+
+  Future<void> _pickAndPreviewImage(ImageSource source) async {
+    try {
+      final picked = await _imagePicker.pickImage(
+        source: source,
+        maxWidth: 1024,
+        maxHeight: 1024,
+        imageQuality: 85,
+      );
+      if (picked == null || !mounted) return;
+
+      final file = File(picked.path);
+      final confirmed = await _showAvatarPreviewDialog(file);
+      if (confirmed == true) {
+        await _uploadAvatar(file);
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Error selecting image: $e'),
+            backgroundColor: Colors.red,
+          ),
+        );
+      }
+    }
+  }
+
+  Future<bool?> _showAvatarPreviewDialog(File file) {
+    return showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        backgroundColor: Theme.of(context).colorScheme.surface,
+        title: const Text('Update profile photo?'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ClipOval(
+              child: Image.file(
+                file,
+                width: 140,
+                height: 140,
+                fit: BoxFit.cover,
+              ),
+            ),
+            const SizedBox(height: 12),
+            Text(
+              'This will replace your current profile photo.',
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                color: Theme.of(context).colorScheme.onSurfaceVariant,
+                fontSize: 12,
+              ),
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Cancel'),
+          ),
+          ElevatedButton(
+            onPressed: () => Navigator.pop(context, true),
+            style: ElevatedButton.styleFrom(
+              backgroundColor: Colors.green.shade600,
+            ),
+            child: const Text('Confirm'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _uploadAvatar(File file) async {
+    setState(() {
+      _isAvatarUpdating = true;
+    });
+
+    try {
+      final result = await _supabaseService.uploadAvatar(file);
+
+      if (result['success'] == true) {
+        final newUrl = result['avatar_url'] as String?;
+
+        if (mounted) {
+          setState(() {
+            _avatarUrl = newUrl;
+          });
+
+          context.read<UserProfileController>().updateAvatarUrl(newUrl);
+
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text('Profile photo updated'),
+              backgroundColor: Colors.green,
+            ),
+          );
+
+          widget.onProfileUpdated();
+        }
+      } else {
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text('Failed to update photo: ${result['error']}'),
+              backgroundColor: Colors.red,
+            ),
+          );
+        }
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Error uploading photo: $e'),
+            backgroundColor: Colors.red,
+          ),
+        );
+      }
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isAvatarUpdating = false;
+        });
+      }
+    }
+  }
+
+  Future<void> _confirmAndRemoveAvatar() async {
+    if (_isAvatarUpdating) return;
+
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        backgroundColor: Theme.of(context).colorScheme.surface,
+        title: const Text('Remove profile photo?'),
+        content: const Text(
+          'Your profile photo will be removed and replaced with your initials.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Cancel'),
+          ),
+          ElevatedButton(
+            onPressed: () => Navigator.pop(context, true),
+            style: ElevatedButton.styleFrom(
+              backgroundColor: Colors.red.shade400,
+            ),
+            child: const Text('Remove'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed != true) return;
+    await _removeAvatar();
+  }
+
+  Future<void> _removeAvatar() async {
+    setState(() {
+      _isAvatarUpdating = true;
+    });
+
+    try {
+      final result = await _supabaseService.removeAvatar();
+
+      if (result['success'] == true) {
+        if (mounted) {
+          setState(() {
+            _avatarUrl = null;
+          });
+
+          context.read<UserProfileController>().updateAvatarUrl(null);
+
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text('Profile photo removed'),
+              backgroundColor: Colors.green,
+            ),
+          );
+
+          widget.onProfileUpdated();
+        }
+      } else {
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text('Failed to remove photo: ${result['error']}'),
+              backgroundColor: Colors.red,
+            ),
+          );
+        }
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Error removing photo: $e'),
+            backgroundColor: Colors.red,
+          ),
+        );
+      }
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isAvatarUpdating = false;
+        });
+      }
+    }
+  }
+
+  // Deterministic color per user, matching the pattern already used for
+  // initials avatars in team_members_screen.dart.
+  Color _avatarColorFor(String seed) {
+    const colors = [
+      Colors.blue,
+      Colors.green,
+      Colors.orange,
+      Colors.purple,
+      Colors.red,
+      Colors.teal,
+      Colors.indigo,
+      Colors.pink,
+    ];
+    return colors[seed.hashCode.abs() % colors.length];
+  }
+
+  String _initialsFor(String? name) {
+    final trimmed = name?.trim() ?? '';
+    if (trimmed.isEmpty) return '?';
+    final parts = trimmed.split(RegExp(r'\s+'));
+    final first = parts.first.isNotEmpty ? parts.first[0] : '';
+    final last =
+        parts.length > 1 && parts.last.isNotEmpty ? parts.last[0] : '';
+    final initials = (first + last).toUpperCase();
+    return initials.isEmpty ? '?' : initials;
+  }
+
+  Widget _buildAvatar() {
+    final displayName = _fullName ?? widget.userProfile['full_name'];
+    final seed = (displayName ?? _email ?? widget.userProfile['id'] ?? '?')
+        .toString();
+
+    if (_avatarUrl != null && _avatarUrl!.isNotEmpty) {
+      return ClipOval(
+        child: Image.network(
+          _avatarUrl!,
+          width: 100,
+          height: 100,
+          fit: BoxFit.cover,
+          loadingBuilder: (context, child, progress) {
+            if (progress == null) return child;
+            return Container(
+              width: 100,
+              height: 100,
+              color: Theme.of(context).colorScheme.surfaceVariant,
+              child: const Center(
+                child: CircularProgressIndicator(strokeWidth: 2),
+              ),
+            );
+          },
+          errorBuilder: (context, error, stackTrace) => Container(
+            width: 100,
+            height: 100,
+            color: _avatarColorFor(seed),
+            alignment: Alignment.center,
+            child: Text(
+              _initialsFor(displayName),
+              style: const TextStyle(
+                color: Colors.white,
+                fontSize: 32,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    return Container(
+      width: 100,
+      height: 100,
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        color: _avatarColorFor(seed),
+      ),
+      alignment: Alignment.center,
+      child: Text(
+        _initialsFor(displayName),
+        style: const TextStyle(
+          color: Colors.white,
+          fontSize: 32,
+          fontWeight: FontWeight.bold,
+        ),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -152,49 +494,76 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     Center(
-                      child: Stack(
-                        alignment: Alignment.bottomRight,
+                      child: Column(
                         children: [
-                          Container(
-                            width: 100,
-                            height: 100,
-                            decoration: BoxDecoration(
-                              shape: BoxShape.circle,
-                              color: Colors.white,
-                              border: Border.all(color: Colors.white, width: 3),
-                              boxShadow: [
-                                BoxShadow(
-                                  color: Theme.of(context)
-                                      .colorScheme
-                                      .shadow
-                                      .withOpacity(0.2),
-                                  blurRadius: 10,
-                                  offset: const Offset(0, 5),
+                          Stack(
+                            alignment: Alignment.bottomRight,
+                            children: [
+                              Container(
+                                width: 100,
+                                height: 100,
+                                decoration: BoxDecoration(
+                                  shape: BoxShape.circle,
+                                  border: Border.all(
+                                      color: Colors.white, width: 3),
+                                  boxShadow: [
+                                    BoxShadow(
+                                      color: Theme.of(context)
+                                          .colorScheme
+                                          .shadow
+                                          .withOpacity(0.2),
+                                      blurRadius: 10,
+                                      offset: const Offset(0, 5),
+                                    ),
+                                  ],
                                 ),
-                              ],
-                            ),
-                            child: Icon(
-                              Icons.person,
-                              size: 50,
-                              color: Theme.of(context).colorScheme.onSurface,
-                            ),
+                                child: _buildAvatar(),
+                              ),
+                              InkWell(
+                                onTap: _isAvatarUpdating
+                                    ? null
+                                    : _showImageSourceActionSheet,
+                                customBorder: const CircleBorder(),
+                                child: Container(
+                                  padding: const EdgeInsets.all(8),
+                                  decoration: BoxDecoration(
+                                    color: Colors.green.shade400,
+                                    shape: BoxShape.circle,
+                                  ),
+                                  child: _isAvatarUpdating
+                                      ? const SizedBox(
+                                          width: 16,
+                                          height: 16,
+                                          child: CircularProgressIndicator(
+                                            strokeWidth: 2,
+                                            color: Colors.white,
+                                          ),
+                                        )
+                                      : const Icon(
+                                          Icons.camera_alt,
+                                          size: 16,
+                                          color: Colors.white,
+                                        ),
+                                ),
+                              ),
+                            ],
                           ),
-                          Container(
-                            padding: const EdgeInsets.all(8),
-                            decoration: BoxDecoration(
-                              color: Colors.green.shade400,
-                              shape: BoxShape.circle,
+                          if (_avatarUrl != null && _avatarUrl!.isNotEmpty)
+                            TextButton.icon(
+                              onPressed: _isAvatarUpdating
+                                  ? null
+                                  : _confirmAndRemoveAvatar,
+                              icon: Icon(Icons.delete_outline,
+                                  color: Colors.red.shade400, size: 18),
+                              label: Text(
+                                'Remove Photo',
+                                style: TextStyle(color: Colors.red.shade400),
+                              ),
                             ),
-                            child: const Icon(
-                              Icons.camera_alt,
-                              size: 16,
-                              color: Colors.white,
-                            ),
-                          ),
                         ],
                       ),
                     ),
-                    const SizedBox(height: 32),
+                    const SizedBox(height: 16),
                     Text(
                       'Personal Information',
                       style: Theme.of(context)

--- a/lib/screens/profile/edit_profile_screen.dart
+++ b/lib/screens/profile/edit_profile_screen.dart
@@ -1,4 +1,4 @@
-import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
@@ -173,10 +173,16 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
       );
       if (picked == null || !mounted) return;
 
-      final file = File(picked.path);
-      final confirmed = await _showAvatarPreviewDialog(file);
+      // Read bytes rather than using picked.path: XFile.path has no real
+      // filesystem backing on Flutter Web, so both the preview and the
+      // upload work from bytes instead, which behave identically on web,
+      // mobile, and desktop.
+      final bytes = await picked.readAsBytes();
+      if (!mounted) return;
+
+      final confirmed = await _showAvatarPreviewDialog(bytes);
       if (confirmed == true) {
-        await _uploadAvatar(file);
+        await _uploadAvatar(bytes);
       }
     } catch (e) {
       if (mounted) {
@@ -190,7 +196,7 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
     }
   }
 
-  Future<bool?> _showAvatarPreviewDialog(File file) {
+  Future<bool?> _showAvatarPreviewDialog(Uint8List bytes) {
     return showDialog<bool>(
       context: context,
       builder: (context) => AlertDialog(
@@ -200,8 +206,8 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
           mainAxisSize: MainAxisSize.min,
           children: [
             ClipOval(
-              child: Image.file(
-                file,
+              child: Image.memory(
+                bytes,
                 width: 140,
                 height: 140,
                 fit: BoxFit.cover,
@@ -235,13 +241,13 @@ class _EditProfileScreenState extends State<EditProfileScreen> {
     );
   }
 
-  Future<void> _uploadAvatar(File file) async {
+  Future<void> _uploadAvatar(Uint8List bytes) async {
     setState(() {
       _isAvatarUpdating = true;
     });
 
     try {
-      final result = await _supabaseService.uploadAvatar(file);
+      final result = await _supabaseService.uploadAvatar(bytes);
 
       if (result['success'] == true) {
         final newUrl = result['avatar_url'] as String?;

--- a/lib/screens/profile/profile_screen.dart
+++ b/lib/screens/profile/profile_screen.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import '../../providers/user_profile_provider.dart';
 import '../../services/supabase_service.dart';
 import '../../services/navigation_service.dart';
 import '../../theme/app_theme_mode.dart';
 import '../../theme/theme_controller.dart';
+import '../../widgets/custom_widgets.dart';
 import '../auth/login_screen.dart';
 import 'team_members_screen.dart';
 import 'edit_profile_screen.dart';
@@ -18,28 +20,35 @@ class ProfileScreen extends StatefulWidget {
 class _ProfileScreenState extends State<ProfileScreen> {
   final _supabaseService = SupabaseService();
   bool _isLoading = true;
-  Map<String, dynamic>? _userProfile;
+  // The current user's own profile (avatar, name, role, team) now lives in
+  // UserProfileController and is read reactively in build(). _userTeams is
+  // the list of ALL teams this user belongs to (for the team switcher) --
+  // that's not part of UserProfileController, which only holds the single
+  // currently-active profile row, so it's still fetched directly here.
   List<Map<String, dynamic>> _userTeams = [];
 
   @override
   void initState() {
     super.initState();
-    _loadUserProfile();
+    _loadUserTeams();
   }
 
-  Future<void> _loadUserProfile() async {
+  Future<void> _loadUserTeams({bool forceRefreshProfile = false}) async {
     setState(() {
       _isLoading = true;
     });
 
     try {
-      final profile = await _supabaseService.getCurrentUserProfile();
+      final profileController = context.read<UserProfileController>();
+      if (forceRefreshProfile || !profileController.isLoaded) {
+        await profileController.refresh(forceRefresh: forceRefreshProfile);
+      }
 
-      // Also load all teams associated with the user's email
-      if (profile != null && profile['email'] != null) {
+      // Load all teams associated with the user's email
+      final email = profileController.email;
+      if (email != null) {
         try {
-          final teamsResponse =
-              await _supabaseService.getUserTeams(profile['email']);
+          final teamsResponse = await _supabaseService.getUserTeams(email);
           if (teamsResponse['success'] == true &&
               teamsResponse['teams'] != null) {
             _userTeams =
@@ -52,7 +61,6 @@ class _ProfileScreenState extends State<ProfileScreen> {
 
       if (mounted) {
         setState(() {
-          _userProfile = profile;
           _isLoading = false;
         });
       }
@@ -149,11 +157,17 @@ class _ProfileScreenState extends State<ProfileScreen> {
       );
     }
 
-    final String fullName = _userProfile?['full_name'] ?? 'User';
-    final String role = _userProfile?['role'] ?? 'member';
+    // Reactive: rebuilds automatically whenever the shared profile (e.g. the
+    // avatar) changes, including from EditProfileScreen on another screen.
+    final profileController = context.watch<UserProfileController>();
+    final String fullName = profileController.fullName ?? 'User';
+    final String role = profileController.role ?? 'member';
     final String roleDisplay = role == 'admin' ? 'Team Admin' : 'Team Member';
-    final String teamName = _userProfile?['teams']?['name'] ?? 'Your Team';
-    final String teamCode = _userProfile?['teams']?['team_code'] ?? '';
+    final String teamName =
+        profileController.profile?['teams']?['name'] ?? 'Your Team';
+    final String teamCode =
+        profileController.profile?['teams']?['team_code'] ?? '';
+    final String? avatarUrl = profileController.avatarUrl;
 
     return Scaffold(
       body: SafeArea(
@@ -216,11 +230,10 @@ class _ProfileScreenState extends State<ProfileScreen> {
                                       ),
                                     ],
                                   ),
-                                  child: Icon(
-                                    Icons.person,
-                                    size: 50,
-                                    color:
-                                        Theme.of(context).colorScheme.onSurface,
+                                  child: UserAvatar(
+                                    avatarUrl: avatarUrl,
+                                    name: fullName,
+                                    radius: 50,
                                   ),
                                 ),
                                 // Role badge
@@ -312,7 +325,8 @@ class _ProfileScreenState extends State<ProfileScreen> {
               itemCount: _userTeams.length,
               itemBuilder: (context, index) {
                 final team = _userTeams[index];
-                final isCurrentTeam = team['id'] == _userProfile?['team_id'];
+                final isCurrentTeam =
+                    team['id'] == context.read<UserProfileController>().teamId;
 
                 final colorScheme = Theme.of(context).colorScheme;
                 return ListTile(
@@ -377,8 +391,8 @@ class _ProfileScreenState extends State<ProfileScreen> {
       final result = await _supabaseService.switchTeam(teamId);
 
       if (result['success'] == true) {
-        // Reload profile with new team
-        await _loadUserProfile();
+        // Reload profile (forced, to bypass the cache) with the new team
+        await _loadUserTeams(forceRefreshProfile: true);
 
         if (mounted) {
           ScaffoldMessenger.of(context).showSnackBar(
@@ -629,9 +643,12 @@ class _ProfileScreenState extends State<ProfileScreen> {
   }
 
   Widget _buildSettingsSection() {
-    final bool isAdmin = _userProfile?['role'] == 'admin';
-    final String teamId = _userProfile?['teams']?['team_code'] ?? '';
-    final String teamName = _userProfile?['teams']?['name'] ?? 'Your Team';
+    final profileController = context.watch<UserProfileController>();
+    final bool isAdmin = profileController.role == 'admin';
+    final String teamId =
+        profileController.profile?['teams']?['team_code'] ?? '';
+    final String teamName =
+        profileController.profile?['teams']?['name'] ?? 'Your Team';
     final colorScheme = Theme.of(context).colorScheme;
 
     return Column(
@@ -663,9 +680,17 @@ class _ProfileScreenState extends State<ProfileScreen> {
                     context,
                     MaterialPageRoute(
                       builder: (context) => EditProfileScreen(
-                        userProfile: _userProfile!,
+                        userProfile: profileController.profile!,
                         onProfileUpdated: () {
-                          _loadUserProfile();
+                          // updateAvatarUrl() already pushed avatar changes
+                          // into the shared controller directly; a forced
+                          // refresh here also picks up full_name edits,
+                          // which EditProfileScreen saves via
+                          // SupabaseService.updateUserProfile() without
+                          // touching the shared controller itself.
+                          context
+                              .read<UserProfileController>()
+                              .refresh(forceRefresh: true);
                         },
                       ),
                     ),

--- a/lib/screens/profile/profile_screen.dart
+++ b/lib/screens/profile/profile_screen.dart
@@ -79,6 +79,63 @@ class _ProfileScreenState extends State<ProfileScreen> {
     }
   }
 
+  // Guards against navigating to Edit Profile before
+  // UserProfileController.refresh() (fired-and-forgotten in
+  // HomeScreen.initState()) has actually completed -- profile can still be
+  // null at that point (e.g. tapping Edit Profile immediately after login).
+  // Mirrors the same full-screen _isLoading pattern already used for
+  // _switchTeam: block briefly on a fresh refresh() rather than force-
+  // unwrapping data that may not have loaded yet.
+  Future<void> _openEditProfile() async {
+    var profile = context.read<UserProfileController>().profile;
+
+    if (profile == null) {
+      setState(() {
+        _isLoading = true;
+      });
+
+      await context.read<UserProfileController>().refresh();
+
+      if (!mounted) return;
+
+      profile = context.read<UserProfileController>().profile;
+
+      setState(() {
+        _isLoading = false;
+      });
+
+      if (profile == null) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Could not load your profile. Please try again.'),
+            backgroundColor: Colors.red,
+          ),
+        );
+        return;
+      }
+    }
+
+    if (!mounted) return;
+
+    final loadedProfile = profile;
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (context) => EditProfileScreen(
+          userProfile: loadedProfile,
+          onProfileUpdated: () {
+            // updateAvatarUrl() already pushed avatar changes into the
+            // shared controller directly; a forced refresh here also
+            // picks up full_name edits, which EditProfileScreen saves via
+            // SupabaseService.updateUserProfile() without touching the
+            // shared controller itself.
+            context.read<UserProfileController>().refresh(forceRefresh: true);
+          },
+        ),
+      ),
+    );
+  }
+
   Future<void> _handleLogout() async {
     //Confirmation dialog
     final shouldLogout = await showDialog<bool>(
@@ -675,27 +732,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
                 title: 'Edit Profile',
                 subtitle: 'Update your personal information',
                 iconColor: Colors.blue.shade400,
-                onTap: () {
-                  Navigator.push(
-                    context,
-                    MaterialPageRoute(
-                      builder: (context) => EditProfileScreen(
-                        userProfile: profileController.profile!,
-                        onProfileUpdated: () {
-                          // updateAvatarUrl() already pushed avatar changes
-                          // into the shared controller directly; a forced
-                          // refresh here also picks up full_name edits,
-                          // which EditProfileScreen saves via
-                          // SupabaseService.updateUserProfile() without
-                          // touching the shared controller itself.
-                          context
-                              .read<UserProfileController>()
-                              .refresh(forceRefresh: true);
-                        },
-                      ),
-                    ),
-                  );
-                },
+                onTap: _openEditProfile,
               ),
               const Divider(color: Colors.grey),
               _buildSettingItem(

--- a/lib/screens/profile/team_members_screen.dart
+++ b/lib/screens/profile/team_members_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../../services/supabase_service.dart';
+import '../../widgets/custom_widgets.dart';
 
 class TeamMembersScreen extends StatefulWidget {
   final String teamId;
@@ -54,23 +55,6 @@ class _TeamMembersScreenState extends State<TeamMembersScreen> {
         );
       }
     }
-  }
-
-  Color _getAvatarColor(String name) {
-    // Generate a consistent color based on the name
-    final colors = [
-      Colors.blue,
-      Colors.green,
-      Colors.orange,
-      Colors.purple,
-      Colors.red,
-      Colors.teal,
-      Colors.indigo,
-      Colors.pink,
-    ];
-
-    int hashCode = name.hashCode;
-    return colors[hashCode.abs() % colors.length];
   }
 
   @override
@@ -131,8 +115,7 @@ class _TeamMembersScreenState extends State<TeamMembersScreen> {
         final name = member['full_name'] ?? 'Unknown';
         final email = member['email'] ?? '';
         final role = member['role'] ?? 'member';
-        final firstLetter = name.isNotEmpty ? name[0].toUpperCase() : '?';
-        final avatarColor = _getAvatarColor(name);
+        final avatarUrl = member['avatar_url'] as String?;
 
         return Card(
           margin: const EdgeInsets.only(bottom: 12),
@@ -143,17 +126,10 @@ class _TeamMembersScreenState extends State<TeamMembersScreen> {
           ),
           child: ListTile(
             contentPadding: const EdgeInsets.all(12),
-            leading: CircleAvatar(
-              backgroundColor: avatarColor,
+            leading: UserAvatar(
+              avatarUrl: avatarUrl,
+              name: name,
               radius: 24,
-              child: Text(
-                firstLetter,
-                style: const TextStyle(
-                  color: Colors.white,
-                  fontWeight: FontWeight.bold,
-                  fontSize: 20,
-                ),
-              ),
             ),
             title: Text(
               name,

--- a/lib/services/supabase_service.dart
+++ b/lib/services/supabase_service.dart
@@ -921,8 +921,17 @@ class SupabaseService {
 
       final publicUrl = _client.storage.from('avatars').getPublicUrl(path);
 
+      // The storage path is fixed per user, so the public URL is identical
+      // across uploads -- Image.network (and browser caching generally)
+      // caches by URL, so without a cache-busting suffix a re-uploaded
+      // avatar could keep showing the previous cached image. Append one
+      // here so every downstream consumer (DB, result map, UI) sees and
+      // uses the same versioned URL.
+      final versionedUrl =
+          '$publicUrl?v=${DateTime.now().millisecondsSinceEpoch}';
+
       final profileUpdated =
-          await updateUserProfile({'avatar_url': publicUrl});
+          await updateUserProfile({'avatar_url': versionedUrl});
       if (!profileUpdated) {
         return {
           'success': false,
@@ -932,7 +941,7 @@ class SupabaseService {
 
       return {
         'success': true,
-        'avatar_url': publicUrl,
+        'avatar_url': versionedUrl,
       };
     } catch (e) {
       debugPrint('Error uploading avatar: $e');
@@ -966,11 +975,23 @@ class SupabaseService {
 
       try {
         await _client.storage.from('avatars').remove([path]);
-      } catch (e) {
-        // The object may not exist (e.g. the user never uploaded an
-        // avatar) -- that's not a hard failure as long as we can still
-        // clear avatar_url on the profile below.
-        debugPrint('Error removing avatar object (continuing): $e');
+      } on StorageException catch (e) {
+        // Only treat a genuine "object not found" as idempotent/OK (e.g.
+        // the user never uploaded an avatar, or it was already removed).
+        // Any other StorageException (permissions, network, etc.) is a
+        // real failure -- avatar_url must NOT be cleared in that case, or
+        // the app would think there's no avatar while the file is still
+        // sitting in (and publicly accessible from) storage.
+        final isNotFound = e.statusCode == '404' ||
+            (e.error?.toLowerCase() == 'not_found') ||
+            e.message.toLowerCase().contains('not found');
+        if (!isNotFound) {
+          return {
+            'success': false,
+            'error': 'Failed to remove avatar file: ${e.message}',
+          };
+        }
+        debugPrint('Avatar object already absent, continuing: ${e.message}');
       }
 
       final profileUpdated =

--- a/lib/services/supabase_service.dart
+++ b/lib/services/supabase_service.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:io';
 import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
@@ -879,6 +880,110 @@ class SupabaseService {
     } catch (e) {
       debugPrint('Error updating profile: $e');
       return false;
+    }
+  }
+
+  // Upload/replace the current user's avatar image.
+  // Storage path is fixed as '<user_id>/avatar.jpg' so each new upload
+  // overwrites the previous one at the same path (upsert: true), matching
+  // the path convention documented in
+  // supabase/migrations/20251021110000_avatar_url_and_storage.sql and
+  // avoiding orphaned old avatar files accumulating in storage.
+  Future<Map<String, dynamic>> uploadAvatar(File imageFile) async {
+    try {
+      if (!_isInitialized) {
+        return {
+          'success': false,
+          'error': 'Supabase is not initialized',
+        };
+      }
+
+      final user = _client.auth.currentUser;
+      if (user == null) {
+        return {
+          'success': false,
+          'error': 'User not authenticated',
+        };
+      }
+
+      final path = '${user.id}/avatar.jpg';
+
+      await _client.storage.from('avatars').upload(
+            path,
+            imageFile,
+            fileOptions: const FileOptions(upsert: true),
+          );
+
+      final publicUrl = _client.storage.from('avatars').getPublicUrl(path);
+
+      final profileUpdated =
+          await updateUserProfile({'avatar_url': publicUrl});
+      if (!profileUpdated) {
+        return {
+          'success': false,
+          'error': 'Avatar uploaded but failed to update profile',
+        };
+      }
+
+      return {
+        'success': true,
+        'avatar_url': publicUrl,
+      };
+    } catch (e) {
+      debugPrint('Error uploading avatar: $e');
+      return {
+        'success': false,
+        'error': e.toString(),
+      };
+    }
+  }
+
+  // Remove the current user's avatar: deletes the storage object (if any)
+  // and clears avatar_url on the user's profile.
+  Future<Map<String, dynamic>> removeAvatar() async {
+    try {
+      if (!_isInitialized) {
+        return {
+          'success': false,
+          'error': 'Supabase is not initialized',
+        };
+      }
+
+      final user = _client.auth.currentUser;
+      if (user == null) {
+        return {
+          'success': false,
+          'error': 'User not authenticated',
+        };
+      }
+
+      final path = '${user.id}/avatar.jpg';
+
+      try {
+        await _client.storage.from('avatars').remove([path]);
+      } catch (e) {
+        // The object may not exist (e.g. the user never uploaded an
+        // avatar) -- that's not a hard failure as long as we can still
+        // clear avatar_url on the profile below.
+        debugPrint('Error removing avatar object (continuing): $e');
+      }
+
+      final profileUpdated =
+          await updateUserProfile({'avatar_url': null});
+      if (!profileUpdated) {
+        return {
+          'success': false,
+          'error': 'Failed to clear avatar on profile',
+        };
+      }
+
+      return {'success': true};
+    } catch (e) {
+      debugPrint('Error removing avatar: $e');
+      return {
+        'success': false,
+        'error': e.toString(),
+      };
     }
   }
 

--- a/lib/services/supabase_service.dart
+++ b/lib/services/supabase_service.dart
@@ -1,5 +1,5 @@
 import 'dart:convert';
-import 'dart:io';
+import 'dart:typed_data';
 import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
@@ -889,7 +889,12 @@ class SupabaseService {
   // the path convention documented in
   // supabase/migrations/20251021110000_avatar_url_and_storage.sql and
   // avoiding orphaned old avatar files accumulating in storage.
-  Future<Map<String, dynamic>> uploadAvatar(File imageFile) async {
+  //
+  // Takes raw bytes rather than a dart:io File: File-based upload
+  // (StorageFileApi.upload) is not supported on Flutter Web, since
+  // dart:io's File has no real filesystem backing there. uploadBinary()
+  // works identically across web, mobile, and desktop.
+  Future<Map<String, dynamic>> uploadAvatar(Uint8List imageBytes) async {
     try {
       if (!_isInitialized) {
         return {
@@ -908,9 +913,9 @@ class SupabaseService {
 
       final path = '${user.id}/avatar.jpg';
 
-      await _client.storage.from('avatars').upload(
+      await _client.storage.from('avatars').uploadBinary(
             path,
-            imageFile,
+            imageBytes,
             fileOptions: const FileOptions(upsert: true),
           );
 

--- a/lib/widgets/custom_widgets.dart
+++ b/lib/widgets/custom_widgets.dart
@@ -199,6 +199,140 @@ class CustomLoading extends StatelessWidget {
   }
 }
 
+/// Deterministic background color derived from [name], shared by every
+/// initials-fallback avatar in the app so the same person always gets the
+/// same color regardless of which screen renders them.
+Color avatarColorForName(String name) {
+  const colors = [
+    Colors.blue,
+    Colors.green,
+    Colors.orange,
+    Colors.purple,
+    Colors.red,
+    Colors.teal,
+    Colors.indigo,
+    Colors.pink,
+  ];
+  return colors[name.hashCode.abs() % colors.length];
+}
+
+/// Up to two initials derived from [name] (first letter of the first and
+/// last word), used as the fallback avatar content when no avatarUrl is set.
+String avatarInitialsForName(String name) {
+  final trimmed = name.trim();
+  if (trimmed.isEmpty) return '?';
+  final parts = trimmed.split(RegExp(r'\s+'));
+  final first = parts.first.isNotEmpty ? parts.first[0] : '';
+  final last = parts.length > 1 && parts.last.isNotEmpty ? parts.last[0] : '';
+  final initials = (first + last).toUpperCase();
+  return initials.isEmpty ? '?' : initials;
+}
+
+/// Circular avatar used anywhere the app renders a user -- the current user
+/// or another team member. Shows [avatarUrl] if set (with a loading spinner
+/// and a graceful fallback if the image fails to load), otherwise initials
+/// derived from [name] on a deterministic background color.
+class UserAvatar extends StatelessWidget {
+  final String? avatarUrl;
+  final String name;
+  final double radius;
+  final VoidCallback? onTap;
+
+  const UserAvatar({
+    Key? key,
+    required this.name,
+    this.avatarUrl,
+    this.radius = 20,
+    this.onTap,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final diameter = radius * 2;
+    final color = avatarColorForName(name);
+    final fontSize = radius * 0.8;
+    final initials = avatarInitialsForName(name);
+
+    Widget avatar;
+    if (avatarUrl != null && avatarUrl!.isNotEmpty) {
+      avatar = ClipOval(
+        child: Image.network(
+          avatarUrl!,
+          width: diameter,
+          height: diameter,
+          fit: BoxFit.cover,
+          loadingBuilder: (context, child, progress) {
+            if (progress == null) return child;
+            return Container(
+              width: diameter,
+              height: diameter,
+              color: Theme.of(context).colorScheme.surfaceVariant,
+              alignment: Alignment.center,
+              child: SizedBox(
+                width: radius,
+                height: radius,
+                child: const CircularProgressIndicator(strokeWidth: 2),
+              ),
+            );
+          },
+          errorBuilder: (context, error, stackTrace) => _InitialsCircle(
+            diameter: diameter,
+            color: color,
+            initials: initials,
+            fontSize: fontSize,
+          ),
+        ),
+      );
+    } else {
+      avatar = _InitialsCircle(
+        diameter: diameter,
+        color: color,
+        initials: initials,
+        fontSize: fontSize,
+      );
+    }
+
+    if (onTap == null) return avatar;
+    return InkWell(
+      onTap: onTap,
+      customBorder: const CircleBorder(),
+      child: avatar,
+    );
+  }
+}
+
+class _InitialsCircle extends StatelessWidget {
+  final double diameter;
+  final Color color;
+  final String initials;
+  final double fontSize;
+
+  const _InitialsCircle({
+    required this.diameter,
+    required this.color,
+    required this.initials,
+    required this.fontSize,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: diameter,
+      height: diameter,
+      decoration: BoxDecoration(shape: BoxShape.circle, color: color),
+      alignment: Alignment.center,
+      child: Text(
+        initials,
+        style: TextStyle(
+          color: Colors.white,
+          fontWeight: FontWeight.bold,
+          fontSize: fontSize,
+        ),
+      ),
+    );
+  }
+}
+
 // Dashboard Loading Skeleton
 class DashboardLoadingSkeleton extends StatelessWidget {
   const DashboardLoadingSkeleton({Key? key}) : super(key: key);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -74,6 +74,9 @@ dependencies:
   googleapis: ^13.1.0
   googleapis_auth: ^1.4.1
 
+  # Image picking (profile avatar upload)
+  image_picker: ^1.1.2
+
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/sqls/11_avatar_url_and_storage.sql
+++ b/sqls/11_avatar_url_and_storage.sql
@@ -38,15 +38,15 @@ ON CONFLICT (id) DO NOTHING;
 -- Anyone (including anonymous/unauthenticated requests) can read avatar
 -- objects, since the bucket is public and avatars must render for any
 -- viewer in the app.
-DROP POLICY IF EXISTS "Public can view avatars" ON storage.objects;
-CREATE POLICY "Public can view avatars"
+DROP POLICY IF EXISTS avatars_public_select ON storage.objects;
+CREATE POLICY avatars_public_select
   ON storage.objects FOR SELECT
   TO public
   USING (bucket_id = 'avatars');
 
 -- An authenticated user may only upload into their own user-id folder.
-DROP POLICY IF EXISTS "Users can upload their own avatar" ON storage.objects;
-CREATE POLICY "Users can upload their own avatar"
+DROP POLICY IF EXISTS avatars_owner_insert ON storage.objects;
+CREATE POLICY avatars_owner_insert
   ON storage.objects FOR INSERT
   TO authenticated
   WITH CHECK (
@@ -55,8 +55,8 @@ CREATE POLICY "Users can upload their own avatar"
   );
 
 -- An authenticated user may only update objects in their own user-id folder.
-DROP POLICY IF EXISTS "Users can update their own avatar" ON storage.objects;
-CREATE POLICY "Users can update their own avatar"
+DROP POLICY IF EXISTS avatars_owner_update ON storage.objects;
+CREATE POLICY avatars_owner_update
   ON storage.objects FOR UPDATE
   TO authenticated
   USING (
@@ -69,8 +69,8 @@ CREATE POLICY "Users can update their own avatar"
   );
 
 -- An authenticated user may only delete objects in their own user-id folder.
-DROP POLICY IF EXISTS "Users can delete their own avatar" ON storage.objects;
-CREATE POLICY "Users can delete their own avatar"
+DROP POLICY IF EXISTS avatars_owner_delete ON storage.objects;
+CREATE POLICY avatars_owner_delete
   ON storage.objects FOR DELETE
   TO authenticated
   USING (

--- a/sqls/11_avatar_url_and_storage.sql
+++ b/sqls/11_avatar_url_and_storage.sql
@@ -1,0 +1,79 @@
+-- Add profile avatar support: an avatar_url column on users, plus a public
+-- Supabase Storage bucket (and RLS policies on storage.objects) to host the
+-- uploaded images. This migration only adds the DB/storage foundation --
+-- the Flutter-side image picker and upload UI are implemented separately.
+
+-- =============================================================================
+-- Task 1: avatar_url column
+-- =============================================================================
+-- Stores the public URL of the user's uploaded avatar image (populated after
+-- the image is uploaded to the `avatars` Storage bucket below). NULL until
+-- the user uploads an avatar; the app falls back to an initials/icon
+-- placeholder when this is NULL.
+ALTER TABLE users ADD COLUMN IF NOT EXISTS avatar_url TEXT;
+
+-- =============================================================================
+-- Task 2: `avatars` Storage bucket
+-- =============================================================================
+-- Public bucket: avatar images are non-sensitive and need to be displayable
+-- everywhere in the app (chat, tasks, tickets, team members, etc.) via a
+-- plain public URL, without generating signed URLs per view.
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('avatars', 'avatars', true)
+ON CONFLICT (id) DO NOTHING;
+
+-- Object path convention: <user_id>/<filename>, e.g.
+--   550e8400-e29b-41d4-a716-446655440000/avatar.jpg
+-- i.e. the FIRST path segment of the object's `name` (the path within the
+-- `avatars` bucket -- NOT including the bucket name itself, which is already
+-- the separate `bucket_id` column) is always the uploading user's auth.uid().
+-- storage.foldername(name) splits that path into an array of folder
+-- segments, so (storage.foldername(name))[1] is that user-id segment.
+-- The filename portion is intentionally unconstrained by these policies, so
+-- the upload implementation is free to use a fixed name (e.g. always
+-- "avatar.jpg", overwritten on each upload) or a unique name per upload --
+-- whichever convention the Dart upload code adopts, ownership is enforced by
+-- the same first-path-segment check either way.
+
+-- Anyone (including anonymous/unauthenticated requests) can read avatar
+-- objects, since the bucket is public and avatars must render for any
+-- viewer in the app.
+DROP POLICY IF EXISTS "Public can view avatars" ON storage.objects;
+CREATE POLICY "Public can view avatars"
+  ON storage.objects FOR SELECT
+  TO public
+  USING (bucket_id = 'avatars');
+
+-- An authenticated user may only upload into their own user-id folder.
+DROP POLICY IF EXISTS "Users can upload their own avatar" ON storage.objects;
+CREATE POLICY "Users can upload their own avatar"
+  ON storage.objects FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    bucket_id = 'avatars'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+-- An authenticated user may only update objects in their own user-id folder.
+DROP POLICY IF EXISTS "Users can update their own avatar" ON storage.objects;
+CREATE POLICY "Users can update their own avatar"
+  ON storage.objects FOR UPDATE
+  TO authenticated
+  USING (
+    bucket_id = 'avatars'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+  )
+  WITH CHECK (
+    bucket_id = 'avatars'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+-- An authenticated user may only delete objects in their own user-id folder.
+DROP POLICY IF EXISTS "Users can delete their own avatar" ON storage.objects;
+CREATE POLICY "Users can delete their own avatar"
+  ON storage.objects FOR DELETE
+  TO authenticated
+  USING (
+    bucket_id = 'avatars'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+  );

--- a/supabase/migrations/20251021110000_avatar_url_and_storage.sql
+++ b/supabase/migrations/20251021110000_avatar_url_and_storage.sql
@@ -38,15 +38,15 @@ ON CONFLICT (id) DO NOTHING;
 -- Anyone (including anonymous/unauthenticated requests) can read avatar
 -- objects, since the bucket is public and avatars must render for any
 -- viewer in the app.
-DROP POLICY IF EXISTS "Public can view avatars" ON storage.objects;
-CREATE POLICY "Public can view avatars"
+DROP POLICY IF EXISTS avatars_public_select ON storage.objects;
+CREATE POLICY avatars_public_select
   ON storage.objects FOR SELECT
   TO public
   USING (bucket_id = 'avatars');
 
 -- An authenticated user may only upload into their own user-id folder.
-DROP POLICY IF EXISTS "Users can upload their own avatar" ON storage.objects;
-CREATE POLICY "Users can upload their own avatar"
+DROP POLICY IF EXISTS avatars_owner_insert ON storage.objects;
+CREATE POLICY avatars_owner_insert
   ON storage.objects FOR INSERT
   TO authenticated
   WITH CHECK (
@@ -55,8 +55,8 @@ CREATE POLICY "Users can upload their own avatar"
   );
 
 -- An authenticated user may only update objects in their own user-id folder.
-DROP POLICY IF EXISTS "Users can update their own avatar" ON storage.objects;
-CREATE POLICY "Users can update their own avatar"
+DROP POLICY IF EXISTS avatars_owner_update ON storage.objects;
+CREATE POLICY avatars_owner_update
   ON storage.objects FOR UPDATE
   TO authenticated
   USING (
@@ -69,8 +69,8 @@ CREATE POLICY "Users can update their own avatar"
   );
 
 -- An authenticated user may only delete objects in their own user-id folder.
-DROP POLICY IF EXISTS "Users can delete their own avatar" ON storage.objects;
-CREATE POLICY "Users can delete their own avatar"
+DROP POLICY IF EXISTS avatars_owner_delete ON storage.objects;
+CREATE POLICY avatars_owner_delete
   ON storage.objects FOR DELETE
   TO authenticated
   USING (

--- a/supabase/migrations/20251021110000_avatar_url_and_storage.sql
+++ b/supabase/migrations/20251021110000_avatar_url_and_storage.sql
@@ -1,0 +1,79 @@
+-- Add profile avatar support: an avatar_url column on users, plus a public
+-- Supabase Storage bucket (and RLS policies on storage.objects) to host the
+-- uploaded images. This migration only adds the DB/storage foundation --
+-- the Flutter-side image picker and upload UI are implemented separately.
+
+-- =============================================================================
+-- Task 1: avatar_url column
+-- =============================================================================
+-- Stores the public URL of the user's uploaded avatar image (populated after
+-- the image is uploaded to the `avatars` Storage bucket below). NULL until
+-- the user uploads an avatar; the app falls back to an initials/icon
+-- placeholder when this is NULL.
+ALTER TABLE users ADD COLUMN IF NOT EXISTS avatar_url TEXT;
+
+-- =============================================================================
+-- Task 2: `avatars` Storage bucket
+-- =============================================================================
+-- Public bucket: avatar images are non-sensitive and need to be displayable
+-- everywhere in the app (chat, tasks, tickets, team members, etc.) via a
+-- plain public URL, without generating signed URLs per view.
+INSERT INTO storage.buckets (id, name, public)
+VALUES ('avatars', 'avatars', true)
+ON CONFLICT (id) DO NOTHING;
+
+-- Object path convention: <user_id>/<filename>, e.g.
+--   550e8400-e29b-41d4-a716-446655440000/avatar.jpg
+-- i.e. the FIRST path segment of the object's `name` (the path within the
+-- `avatars` bucket -- NOT including the bucket name itself, which is already
+-- the separate `bucket_id` column) is always the uploading user's auth.uid().
+-- storage.foldername(name) splits that path into an array of folder
+-- segments, so (storage.foldername(name))[1] is that user-id segment.
+-- The filename portion is intentionally unconstrained by these policies, so
+-- the upload implementation is free to use a fixed name (e.g. always
+-- "avatar.jpg", overwritten on each upload) or a unique name per upload --
+-- whichever convention the Dart upload code adopts, ownership is enforced by
+-- the same first-path-segment check either way.
+
+-- Anyone (including anonymous/unauthenticated requests) can read avatar
+-- objects, since the bucket is public and avatars must render for any
+-- viewer in the app.
+DROP POLICY IF EXISTS "Public can view avatars" ON storage.objects;
+CREATE POLICY "Public can view avatars"
+  ON storage.objects FOR SELECT
+  TO public
+  USING (bucket_id = 'avatars');
+
+-- An authenticated user may only upload into their own user-id folder.
+DROP POLICY IF EXISTS "Users can upload their own avatar" ON storage.objects;
+CREATE POLICY "Users can upload their own avatar"
+  ON storage.objects FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    bucket_id = 'avatars'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+-- An authenticated user may only update objects in their own user-id folder.
+DROP POLICY IF EXISTS "Users can update their own avatar" ON storage.objects;
+CREATE POLICY "Users can update their own avatar"
+  ON storage.objects FOR UPDATE
+  TO authenticated
+  USING (
+    bucket_id = 'avatars'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+  )
+  WITH CHECK (
+    bucket_id = 'avatars'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+-- An authenticated user may only delete objects in their own user-id folder.
+DROP POLICY IF EXISTS "Users can delete their own avatar" ON storage.objects;
+CREATE POLICY "Users can delete their own avatar"
+  ON storage.objects FOR DELETE
+  TO authenticated
+  USING (
+    bucket_id = 'avatars'
+    AND (storage.foldername(name))[1] = auth.uid()::text
+  );


### PR DESCRIPTION
## Closes #102

## 📝 Description

Implements profile avatar upload with real-time, app-wide synchronization, as requested in #102. Previously, users had no way to personalize their profile with a photo — every screen showed a generic person icon or plain initials with no visual identity for team members.

This PR adds the full flow: users can upload a photo from Edit Profile, preview it before committing, and see it reflected instantly across every screen that shows their identity — Profile, Dashboard, and Chat — with no app restart or re-login required. Users can also remove their photo at any time, reverting cleanly to an initials-based fallback.

## 💡 Implementation

### Database & Storage
- New migration adds `avatar_url TEXT` to `users` (nullable — `NULL` means "no avatar set," app falls back to initials)
- New public `avatars` Storage bucket with RLS policies on `storage.objects`:
  - Anyone can **read** (avatars need to render for all viewers)
  - Only the **owning user** can insert/update/delete their own object, enforced via path convention `<user_id>/<filename>` and a `(storage.foldername(name))[1] = auth.uid()::text` check

### Service layer (`SupabaseService`)
- `uploadAvatar(Uint8List bytes)` — uploads to a fixed path (`<user_id>/avatar.jpg`, overwritten on every re-upload rather than accumulating orphaned files), then updates `avatar_url` on the user's row
- `removeAvatar()` — deletes the storage object (tolerating a missing object gracefully) and clears `avatar_url`
- Uses `uploadBinary()` rather than the file-path-based `upload()`, since the latter is unsupported on Flutter Web

### Shared state (`UserProfileController`)
- New `ChangeNotifier`-based provider, modeled directly on the existing `ThemeController` pattern already in the codebase
- Holds the current user's profile reactively; any screen watching it rebuilds automatically the moment it changes
- Loaded once at the single real entry point into the authenticated app (`HomeScreen.initState()`), after confirming every auth flow (login/signup/OTP/team-selection) converges there

### UI
- **Edit Profile**: tap the camera badge → choose Gallery or Camera → preview the picked image with Confirm/Cancel → upload with a loading state → success/error feedback. "Remove Photo" appears only when a photo is set, behind a confirmation dialog
- **Shared `UserAvatar` widget**: one reusable circular-avatar-or-initials component (deterministic color per name) now used consistently in Edit Profile, Profile, Dashboard, Team Members, and Chat — replacing several previously duplicated ad hoc implementations
- Wired up a `ChatMessage.avatarUrl` field that existed in the code but was never actually connected to anything

## 📷 Screenshots

<table>
<tr>
<td align="center"><b>1. Profile — initials fallback</b></td>
<td align="center"><b>2. Edit Profile — camera badge</b></td>
</tr>
<tr>
<td><img width="420" alt="Profile initials fallback" src="https://github.com/user-attachments/assets/2f456938-2f44-4dfc-b08a-25596a9dff5d" /></td>
<td><img width="420" alt="Edit Profile camera badge" src="https://github.com/user-attachments/assets/cdf606e4-3e19-4359-a240-77e54a5e001c" /></td>
</tr>
<tr>
<td align="center"><b>3. Photo source picker</b></td>
<td align="center"><b>4. Uploaded photo + Remove option</b></td>
</tr>
<tr>
<td><img width="420" alt="Gallery/Camera picker" src="https://github.com/user-attachments/assets/92b4247e-ebf5-4ffd-afbc-b98b870007ec" /></td>
<td><img width="420" alt="Uploaded avatar with remove option" src="https://github.com/user-attachments/assets/932122eb-e6d6-470e-bb74-45f3570eb9ea" /></td>
</tr>
<tr>
<td align="center"><b>5. Profile — synced, no restart</b></td>
<td align="center"><b>6. Dashboard — synced</b></td>
</tr>
<tr>
<td><img width="420" alt="Profile synced" src="https://github.com/user-attachments/assets/04fdfad3-6ed1-4891-9ada-f6d7921275e6" /></td>
<td><img width="420" alt="Dashboard synced" src="https://github.com/user-attachments/assets/bef0ec87-7cdb-4921-afb3-911d374846e3" /></td>
</tr>
<tr>
<td align="center" colspan="2"><b>7. Chat — avatar reflected in message bubble</b></td>
</tr>
<tr>
<td colspan="2" align="center"><img width="600" alt="Chat avatar synced" src="https://github.com/user-attachments/assets/631db2fc-e3a8-42e3-bb58-d07ead018ea5" /></td>
</tr>
</table>

## 🔧 Files Changed

| File | Change |
|---|---|
| `sqls/11_avatar_url_and_storage.sql` + mirrored migration | Schema/storage foundation |
| `lib/services/supabase_service.dart` | Upload/remove methods |
| `lib/providers/user_profile_provider.dart` | New shared state controller |
| `lib/main.dart` | Provider registration |
| `lib/widgets/custom_widgets.dart` | Shared `UserAvatar` widget |
| `lib/screens/profile/edit_profile_screen.dart` | Upload UI |
| `lib/screens/profile/profile_screen.dart` | Avatar rendering + sync + crash fix |
| `lib/screens/home/dashboard_screen.dart` | Avatar rendering + sync |
| `lib/screens/home/home_screen.dart` | Single `refresh()` entry point |
| `lib/screens/chat/chat_screen.dart` | Avatar rendering + sync |
| `lib/screens/profile/team_members_screen.dart` | Migrated to shared widget |
| `pubspec.yaml` | `image_picker` dependency |