### PR TITLE
fix: add back button, fix Resend cooldown, and improve OTP input UX

### DIFF
--- a/lib/screens/auth/verify_otp_screen.dart
+++ b/lib/screens/auth/verify_otp_screen.dart
@@ -334,6 +334,7 @@ class _VerifyOTPScreenState extends State<VerifyOTPScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final resendDisabled = _isLoading || !_canresend;
     return AuthScreenWrapper(
       title: 'Verify Email',
       subtitle: 'Enter the 6-digit code sent to ${widget.email}',
@@ -449,11 +450,16 @@ class _VerifyOTPScreenState extends State<VerifyOTPScreen> {
                   color: Theme.of(context).colorScheme.onSurfaceVariant),
             ),
             TextButton(
-              onPressed: _isLoading ? null : _resendCode,
+              onPressed: resendDisabled ? null : _resendCode,
               child: Text(
                 'Resend',
                 style: TextStyle(
-                  color: Colors.green.shade400,
+                  color: resendDisabled
+                      ? Theme.of(context)
+                          .colorScheme
+                          .onSurfaceVariant
+                          .withOpacity(0.5)
+                      : Colors.green.shade400,
                   fontWeight: FontWeight.w600,
                 ),
               ),

--- a/lib/screens/auth/verify_otp_screen.dart
+++ b/lib/screens/auth/verify_otp_screen.dart
@@ -460,6 +460,14 @@ class _VerifyOTPScreenState extends State<VerifyOTPScreen> {
             ),
           ],
         ),
+        const SizedBox(height: 16),
+        CustomButton(
+          text: 'Back',
+          onPressed: () {
+            NavigationService().goBack();
+          },
+          isOutlined: true,
+        ),
       ],
     );
   }

--- a/lib/screens/auth/verify_otp_screen.dart
+++ b/lib/screens/auth/verify_otp_screen.dart
@@ -30,6 +30,15 @@ class _VerifyOTPScreenState extends State<VerifyOTPScreen> {
     (index) => TextEditingController(),
   );
   final List<FocusNode> _focusNodes = List.generate(6, (index) => FocusNode());
+  // One extra FocusNode per box, purely to intercept backspace key events on
+  // an already-empty box (onChanged never fires for that -- there's no text
+  // change) via ancestor bubbling in the focus tree. Never requests focus
+  // itself (canRequestFocus: false), so it doesn't interfere with the real
+  // per-box FocusNodes above.
+  final List<FocusNode> _backspaceListenerNodes = List.generate(
+    6,
+    (index) => FocusNode(skipTraversal: true, canRequestFocus: false),
+  );
   Timer? _resendTimer;
   bool _showtimertext = false;
   bool _timerStarted = false;
@@ -50,6 +59,9 @@ class _VerifyOTPScreenState extends State<VerifyOTPScreen> {
     for (var node in _focusNodes) {
       node.dispose();
     }
+    for (var node in _backspaceListenerNodes) {
+      node.dispose();
+    }
     super.dispose();
   }
 
@@ -62,6 +74,47 @@ class _VerifyOTPScreenState extends State<VerifyOTPScreen> {
         _otpcomplete = iscomplete;
       });
     }
+  }
+
+  // Handles both normal single-digit typing and a multi-digit paste. Paste
+  // reaches here as a single onChanged call with the full pasted string,
+  // since maxLengthEnforcement is set to none on the field below (default
+  // maxLength enforcement would silently truncate a paste to 1 char before
+  // onChanged ever sees it).
+  void _handleOtpChanged(int index, String value) {
+    if (value.length > 1) {
+      var target = index;
+      for (final digit in value.split('')) {
+        if (target > 5) break;
+        _controllers[target].text = digit;
+        target++;
+      }
+      final lastFilled = target > 5 ? 5 : target;
+      _focusNodes[lastFilled].requestFocus();
+      _controllers[lastFilled].selection = TextSelection.collapsed(
+        offset: _controllers[lastFilled].text.length,
+      );
+      _checkotpcomplete();
+      return;
+    }
+
+    if (value.isNotEmpty) {
+      if (index < 5) {
+        _focusNodes[index + 1].requestFocus();
+      } else {
+        _focusNodes[index].unfocus();
+      }
+    }
+    _checkotpcomplete();
+  }
+
+  // Backspace on an already-empty box: move focus to (and clear) the
+  // previous box, matching standard OTP-input UX.
+  void _handleBackspaceOnEmpty(int index) {
+    if (index == 0) return;
+    _focusNodes[index - 1].requestFocus();
+    _controllers[index - 1].clear();
+    _checkotpcomplete();
   }
   void _showErrorSnackBar(String message) {
   ScaffoldMessenger.of(context).clearSnackBars();
@@ -367,35 +420,39 @@ class _VerifyOTPScreenState extends State<VerifyOTPScreen> {
             (index) => SizedBox(
               width: 50,
               height: 60,
-              child: TextField(
-                controller: _controllers[index],
-                focusNode: _focusNodes[index],
-                keyboardType: TextInputType.number,
-                maxLength: 1,
-                textAlign: TextAlign.center,
-                style: TextStyle(
-                  fontSize: 24,
-                  fontWeight: FontWeight.bold,
-                  color: Theme.of(context).colorScheme.onSurface,
-                ),
-                decoration: InputDecoration(
-                  counterText: '',
-                  filled: true,
-                  border: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(15),
-                  ),
-                ),
-                onChanged: (value) {
-                  if (value.isNotEmpty) {
-                    if (index < 5) {
-                      _focusNodes[index + 1].requestFocus();
-                    } else {
-                      _focusNodes[index].unfocus();
-                      // _handleVerification();
-                    }
+              child: KeyboardListener(
+                focusNode: _backspaceListenerNodes[index],
+                onKeyEvent: (event) {
+                  if (event is KeyDownEvent &&
+                      event.logicalKey == LogicalKeyboardKey.backspace &&
+                      _controllers[index].text.isEmpty) {
+                    _handleBackspaceOnEmpty(index);
                   }
-                  _checkotpcomplete();
                 },
+                child: TextField(
+                  controller: _controllers[index],
+                  focusNode: _focusNodes[index],
+                  keyboardType: TextInputType.number,
+                  maxLength: 1,
+                  // Allow a full pasted string to reach onChanged instead of
+                  // being silently truncated to 1 char before it gets there.
+                  maxLengthEnforcement: MaxLengthEnforcement.none,
+                  inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                    fontSize: 24,
+                    fontWeight: FontWeight.bold,
+                    color: Theme.of(context).colorScheme.onSurface,
+                  ),
+                  decoration: InputDecoration(
+                    counterText: '',
+                    filled: true,
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(15),
+                    ),
+                  ),
+                  onChanged: (value) => _handleOtpChanged(index, value),
+                ),
               ),
             ),
           ),


### PR DESCRIPTION
## Closes #327 

## Description

Addresses three separate usability gaps on the OTP verification screen (`VerifyOTPScreen`), each identified during manual testing of the auth flow. None of these were previously flagged or fixed elsewhere in the codebase — they're small, independent issues that happened to live on the same screen, so this PR bundles them together for review efficiency while keeping the code changes cleanly separated across three commits.

## Problems

1. **No way to leave the screen.** `VerifyOTPScreen` had no back arrow (the shared `AuthScreenWrapper` component has no `AppBar`) and no in-body cancel/back button, unlike `ForgotPasswordScreen` and `SetNewPasswordScreen`, which each already implement their own equivalent button. A user who reaches this screen and changes their mind — whether mid-signup or mid-password-reset — has no in-app way out.

2. **Resend button gave no real feedback during its cooldown.** After requesting a code, there's a 60-second cooldown before another can be sent, tracked by an existing `_canresend` flag. However, the button's `onPressed` was only gated on `_isLoading`, not `_canresend` — so during the cooldown, the button remained fully clickable-looking. Tapping it silently no-opped via an early return inside `_resendCode()`, giving the user no indication the tap did anything (or why it didn't).

3. **The 6-digit code input had no backspace-to-previous-box or paste support.** Each box only auto-advanced focus forward as digits were typed. There was no way to press backspace on an empty box to jump back and correct a previous digit, and pasting a full 6-digit code (e.g. copied from an email or SMS, which is how most users actually enter OTP codes) did nothing useful — `maxLength: 1` silently truncated any paste down to a single character before the input's `onChanged` handler ever saw the rest.

## Changes Made

**Commit 1 — Back button**
Added a `CustomButton(isOutlined: true)` below the Resend row, using `NavigationService().goBack()` rather than a hardcoded "Back to Login" redirect. This screen is reachable from both `SignupScreen` and `ForgotPasswordScreen`, so `goBack()` correctly returns the user to whichever flow brought them here, rather than assuming one specific origin.

**Commit 2 — Resend cooldown fix**
Changed the button's `onPressed` condition to `(_isLoading || !_canresend) ? null : _resendCode`. Also caught and fixed a related issue while implementing this: the "Resend" text had a hardcoded `Colors.green.shade400` style, which would have stayed fully green even with `onPressed: null` — Flutter's automatic disabled-button dimming doesn't override an explicitly-styled child widget. The text now switches to a dimmed `onSurfaceVariant` color when disabled, so the inert state is now genuinely visible, not just functionally inert.

**Commit 3 — OTP backspace and paste support**
- *Backspace:* each of the 6 boxes is now wrapped in a `KeyboardListener` (using a dedicated, non-focus-stealing `FocusNode` per box — `skipTraversal: true`, `canRequestFocus: false`) that intercepts a backspace keydown specifically when the box is already empty. This case can't be detected via `onChanged` alone, since no text change actually occurs when backspacing an empty field.
- *Paste:* set `maxLengthEnforcement: MaxLengthEnforcement.none` so a full pasted string reaches `onChanged` instead of being truncated to one character beforehand, and added `FilteringTextInputFormatter.digitsOnly` to strip any non-digit characters from both typed and pasted input (since `keyboardType: TextInputType.number` alone doesn't block a clipboard paste containing letters). The `onChanged` handler now detects a multi-character value and distributes its digits across the current and subsequent boxes, landing focus on the last box filled.


<img width="1901" height="921" alt="Screenshot 2026-09-17 002008" src="https://github.com/user-attachments/assets/5fdbde7b-f534-49c3-9391-f8810f80f3a7" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for pasting multi-digit OTP codes into the verification form.
  * Backspace on empty OTP fields now moves focus to and clears the previous field.
  * Added a Back button to return to the previous screen.

* **Bug Fixes**
  * Resend is now disabled during loading and cooldown periods, with updated visual feedback.
  * Improved verification and code-resending behavior when leaving the screen during processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->